### PR TITLE
make electrs listen port and bitcoin rpc url configurable

### DIFF
--- a/examples/index.rs
+++ b/examples/index.rs
@@ -18,6 +18,7 @@ fn run() -> Result<()> {
 
     let daemon = Daemon::new(
         &config.daemon_dir,
+        &config.daemon_rpc_url,
         &config.cookie,
         config.network_type,
         &metrics,

--- a/examples/load.rs
+++ b/examples/load.rs
@@ -20,6 +20,7 @@ fn run(config: Config) -> Result<()> {
     metrics.start();
     let daemon = Daemon::new(
         &config.daemon_dir,
+        &config.daemon_rpc_url,
         &config.cookie,
         config.network_type,
         &metrics,

--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -19,6 +19,7 @@ fn run_server(config: &Config) -> Result<()> {
 
     let daemon = Daemon::new(
         &config.daemon_dir,
+        &config.daemon_rpc_url,
         &config.cookie,
         config.network_type,
         &metrics,

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ pub struct Config {
     pub network_type: Network,       // bitcoind JSONRPC endpoint
     pub db_path: PathBuf,            // RocksDB directory path
     pub daemon_dir: PathBuf,         // Bitcoind data directory
+    pub daemon_rpc_url: String,      // Bitcoind rpc ip:port
     pub cookie: String,              // for bitcoind JSONRPC authentication ("USER:PASSWORD")
     pub rpc_addr: SocketAddr,        // for serving Electrum clients
     pub monitoring_addr: SocketAddr, // for Prometheus monitoring
@@ -67,12 +68,38 @@ impl Config {
                     .long("testnet")
                     .help("Connect to a testnet bitcoind instance"),
             )
+            .arg(
+                Arg::with_name("port")
+                    .short("p")
+                    .help("Port to listen to (default: 50001 for mainnet and 60001 for testnet)")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name("daemon_rpc_url")
+                    .long("daemon-rpc-url")
+                    .help("Url of the Bitcoind rpc (default: 127.0.0.1:8332 for mainnet and 127.0.01:18332 for testnet)")
+                    .takes_value(true),
+            )
             .get_matches();
         let network_type = match m.is_present("testnet") {
             false => Network::Mainnet,
             true => Network::Testnet,
         };
         let db_dir = Path::new(m.value_of("db_dir").unwrap_or("./db"));
+
+        let listen_port = value_t!(m, "port", u16).unwrap_or(match network_type {
+            Network::Mainnet => 50001,
+            Network::Testnet => 60001,
+        });
+        let daemon_rpc_url = m.value_of("daemon_rpc_url")
+            .unwrap_or(&format!(
+                "127.0.0.1:{}",
+                match network_type {
+                    Network::Mainnet => 8332,
+                    Network::Testnet => 18332,
+                }
+            ))
+            .to_string();
         let mut daemon_dir = m.value_of("daemon_dir")
             .map(|p| PathBuf::from(p))
             .unwrap_or_else(|| {
@@ -103,12 +130,9 @@ impl Config {
                 Network::Testnet => db_dir.join("testnet"),
             },
             daemon_dir,
+            daemon_rpc_url,
             cookie,
-            rpc_addr: match network_type {
-                Network::Mainnet => "127.0.0.1:50001",
-                Network::Testnet => "127.0.0.1:60001",
-            }.parse()
-                .unwrap(),
+            rpc_addr: format!("127.0.0.1:{}", listen_port).parse().unwrap(),
             monitoring_addr: "127.0.0.1:42024".parse().unwrap(),
         };
         eprintln!("{:?}", config);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -191,19 +191,16 @@ pub struct Daemon {
 impl Daemon {
     pub fn new(
         daemon_dir: &PathBuf,
+        daemon_rpc_url: &str,
         cookie: &str,
         network: Network,
         metrics: &Metrics,
     ) -> Result<Daemon> {
-        let addr = match network {
-            Network::Mainnet => "127.0.0.1:8332",
-            Network::Testnet => "127.0.0.1:18332",
-        };
         let daemon = Daemon {
             daemon_dir: daemon_dir.clone(),
             network,
             conn: Mutex::new(Connection::new(
-                SocketAddr::from_str(addr).unwrap(),
+                SocketAddr::from_str(daemon_rpc_url).unwrap(),
                 base64::encode(cookie),
             )?),
             latency: metrics.histogram_vec(


### PR DESCRIPTION
I tested this locally and seems to work ok. I wanted to check if there was interest and if there's a preference on how to go about it.

This PR is meant to add configurability for the tcp listening port (default to 50001 for mainnet) and for the bitcoin rpc ip:port.

It attempts to avoid repeating the default ports around the code and it defaults to correct ports for mainnet/testnet - i.e. the configurability is meant to be optional.

I'll make updates to the PR based on feedback/interest, results of additional testing, etc