### PR TITLE
remove unused size_on_disk

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -34,7 +34,7 @@ First index sync should take ~1.5 hours:
 ```bash
 $ cargo run --release -- -vvv --timestamp --db-dir ./db [--cookie="USER:PASSWORD"]
 2018-08-17T18:27:42 - INFO - NetworkInfo { version: 179900, subversion: "/Satoshi:0.17.99/" }
-2018-08-17T18:27:42 - INFO - BlockchainInfo { chain: "main", blocks: 537204, headers: 537204, bestblockhash: "0000000000000000002956768ca9421a8ddf4e53b1d81e429bd0125a383e3636", size_on_disk: 204885341685, pruned: false, initialblockdownload: false }
+2018-08-17T18:27:42 - INFO - BlockchainInfo { chain: "main", blocks: 537204, headers: 537204, bestblockhash: "0000000000000000002956768ca9421a8ddf4e53b1d81e429bd0125a383e3636", pruned: false, initialblockdownload: false }
 2018-08-17T18:27:42 - DEBUG - opening DB at "./db/mainnet"
 2018-08-17T18:27:42 - DEBUG - full compaction marker: None
 2018-08-17T18:27:42 - INFO - listing block files at "/home/user/.bitcoin/blocks/blk*.dat"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -100,7 +100,6 @@ pub struct BlockchainInfo {
     blocks: u32,
     headers: u32,
     bestblockhash: String,
-    size_on_disk: u64,
     pruned: bool,
     initialblockdownload: bool,
 }


### PR DESCRIPTION
Not sure if this was intentional, if so please close this PR.

If it wasn't intentional this removes size_on_disk as a field in the BlockchainInfo struct since it is not used anywhere. As per usage.md changes, this does affect logging - since it only affects bitcoind logging it may be ok as user can still log getblockchaininfo via bitcoin-cli.