### PR TITLE
Improve query.get_merkle_proof() performance

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -474,6 +474,21 @@ impl Daemon {
         Ok(block)
     }
 
+    pub fn getblocktxids(&self, blockhash: &Sha256dHash) -> Result<Vec<Sha256dHash>> {
+        self.request(
+            "getblock",
+            json!([blockhash.be_hex_string(), /*verbose=*/ 1]),
+        )?.get("tx")
+        .chain_err(|| "block missing txids")?
+        .as_array()
+        .chain_err(|| "invalid block txids")?
+        .iter()
+        .map(|txid| {
+            Sha256dHash::from_hex(txid.as_str().chain_err(|| "txid not string")?)
+                .chain_err(|| "invalid hex")
+        }).collect::<Result<Vec<Sha256dHash>>>()
+    }
+
     pub fn getblocks(&self, blockhashes: &[Sha256dHash]) -> Result<Vec<Block>> {
         let params_list: Vec<Value> = blockhashes
             .iter()

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,3 @@
-use bitcoin::blockdata::block::Block;
 use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::util::hash::Sha256dHash;
@@ -378,8 +377,7 @@ impl Query {
             .index()
             .get_header(height)
             .chain_err(|| format!("missing block #{}", height))?;
-        let block: Block = self.app.daemon().getblock(&header_entry.hash())?;
-        let mut txids: Vec<Sha256dHash> = block.txdata.iter().map(|tx| tx.txid()).collect();
+        let mut txids = self.app.daemon().getblocktxids(&header_entry.hash())?;
         let pos = txids
             .iter()
             .position(|txid| txid == tx_hash)


### PR DESCRIPTION
Query bitcoind for the list of txids in the block instead of fetching the whole block, deserializing it and re-computing them.