### PR TITLE
Let server banner be configurable

### DIFF
--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -17,6 +17,7 @@ use electrs::{
     index::Index,
     metrics::Metrics,
     query::{Query, TransactionCache},
+    rpc::create_server_banner,
     rpc::RPC,
     signal::Waiter,
     store::{full_compaction, is_fully_compacted, DBStore},
@@ -54,6 +55,7 @@ fn run_server(config: &Config) -> Result<()> {
     }
     .enable_compaction(); // enable auto compactions before starting incremental index updates.
 
+    let server_banner = create_server_banner(daemon.getnetworkinfo()?, &config.server_banner);
     let app = App::new(store, index, daemon)?;
     let tx_cache = TransactionCache::new(config.tx_cache_size);
     let query = Query::new(app.clone(), &metrics, tx_cache);
@@ -63,7 +65,14 @@ fn run_server(config: &Config) -> Result<()> {
         app.update(&signal)?;
         query.update_mempool()?;
         server
-            .get_or_insert_with(|| RPC::start(config.electrum_rpc_addr, query.clone(), &metrics))
+            .get_or_insert_with(|| {
+                RPC::start(
+                    config.electrum_rpc_addr,
+                    query.clone(),
+                    &metrics,
+                    server_banner.clone(),
+                )
+            })
             .notify(); // update subscribed clients
         if let Err(err) = signal.wait(Duration::from_secs(5)) {
             info!("stopping server: {}", err);

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub index_batch_size: usize,
     pub bulk_index_threads: usize,
     pub tx_cache_size: usize,
+    pub server_banner: String,
 }
 
 impl Config {
@@ -107,6 +108,12 @@ impl Config {
                     .long("tx-cache-size")
                     .help("Number of transactions to keep in for query LRU cache")
                     .default_value("10000")  // should be enough for a small wallet.
+            )
+            .arg(
+                Arg::with_name("server_banner")
+                    .long("server-banner")
+                    .help("The banner to be shown in the Electrum console")
+                    .default_value("Welcome to {version} running on {daemonversion}!")
             )
             .get_matches();
 
@@ -192,6 +199,7 @@ impl Config {
             index_batch_size: value_t_or_exit!(m, "index_batch_size", usize),
             bulk_index_threads,
             tx_cache_size: value_t_or_exit!(m, "tx_cache_size", usize),
+            server_banner: value_t_or_exit!(m, "server_banner", String),
         };
         eprintln!("{:?}", config);
         config

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -102,9 +102,9 @@ struct BlockchainInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct NetworkInfo {
+pub struct NetworkInfo {
     version: u64,
-    subversion: String,
+    pub subversion: String,
 }
 
 pub struct MempoolEntry {
@@ -436,7 +436,7 @@ impl Daemon {
         Ok(from_value(info).chain_err(|| "invalid blockchain info")?)
     }
 
-    fn getnetworkinfo(&self) -> Result<NetworkInfo> {
+    pub fn getnetworkinfo(&self) -> Result<NetworkInfo> {
         let info: Value = self.request("getnetworkinfo", json!([]))?;
         Ok(from_value(info).chain_err(|| "invalid network info")?)
     }


### PR DESCRIPTION
This lets the operator set a custom server banner using the configuration flag `--server-banner`. 

In addition it adds the daemon version to the banner.