### PR TITLE
tx_id -> tx_hash in transaction.id_from_pos

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -280,7 +280,7 @@ impl Connection {
             .collect();
 
         Ok(json!({
-            "tx_id" : txid.be_hex_string(),
+            "tx_hash" : txid.be_hex_string(),
             "merkle" : merkle_vec}))
     }
 


### PR DESCRIPTION
Bug found in review of #105 

https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-transaction-id-from-pos