### PR TITLE
Resolve hostname for arguments passing an address

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use dirs::home_dir;
 use num_cpus;
 use std::fs;
 use std::net::SocketAddr;
+use std::net::ToSocketAddrs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use stderrlog;
@@ -28,6 +29,15 @@ pub struct Config {
     pub tx_cache_size: usize,
     pub txid_limit: usize,
     pub server_banner: String,
+}
+
+fn str_to_socketaddr(address: &str, what: &str) -> SocketAddr {
+    address
+        .to_socket_addrs()
+        .expect(&format!("unable to resolve {} address", what))
+        .collect::<Vec<_>>()
+        .pop()
+        .unwrap()
 }
 
 impl Config {
@@ -150,21 +160,21 @@ impl Config {
             Network::Regtest => 24224,
         };
 
-        let daemon_rpc_addr: SocketAddr = m
-            .value_of("daemon_rpc_addr")
-            .unwrap_or(&format!("127.0.0.1:{}", default_daemon_port))
-            .parse()
-            .expect("invalid Bitcoind RPC address");
-        let electrum_rpc_addr: SocketAddr = m
-            .value_of("electrum_rpc_addr")
-            .unwrap_or(&format!("127.0.0.1:{}", default_electrum_port))
-            .parse()
-            .expect("invalid Electrum RPC address");
-        let monitoring_addr: SocketAddr = m
-            .value_of("monitoring_addr")
-            .unwrap_or(&format!("127.0.0.1:{}", default_monitoring_port))
-            .parse()
-            .expect("invalid Prometheus monitoring address");
+        let daemon_rpc_addr: SocketAddr = str_to_socketaddr(
+            m.value_of("daemon_rpc_addr")
+                .unwrap_or(&format!("127.0.0.1:{}", default_daemon_port)),
+            "Bitcoin RPC",
+        );
+        let electrum_rpc_addr: SocketAddr = str_to_socketaddr(
+            m.value_of("electrum_rpc_addr")
+                .unwrap_or(&format!("127.0.0.1:{}", default_electrum_port)),
+            "Electrum RPC",
+        );
+        let monitoring_addr: SocketAddr = str_to_socketaddr(
+            m.value_of("monitoring_addr")
+                .unwrap_or(&format!("127.0.0.1:{}", default_monitoring_port)),
+            "Prometheus monitoring",
+        );
 
         let mut daemon_dir = m
             .value_of("daemon_dir")


### PR DESCRIPTION
This allows hostname to be passed, rather than only IP addresses.

My use case for this is having the bitcoin node running on a separate docker instance. The name of the other docker instance resolves to its docker network IP.