### PR TITLE
Update docs for use with Eclair Mobile

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -118,6 +118,15 @@ $ sudo systemctl restart nginx
 $ electrum --oneserver --server=example:50002:s
 ```
 
+Note: If you are connecting to electrs from Eclair Mobile or another similar client which does not allow self-signed SSL certificates, you can obtain a free SSL certificate as follows:
+
+1. Follow the instructions at https://certbot.eff.org/ to install the certbot on your system.
+2. When certbot obtains the SSL certificates for you, change the SSL paths in the nginx template above as follows:
+```
+ssl_certificate /etc/letsencrypt/live/<your-domain>/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/<your-domain>/privkey.pem;
+```
+
 ### Sample Systemd Unit File
 
 You may wish to have systemd manage electrs so that it's "always on." Here is a sample unit file (which assumes that the bitcoind unit file is `bitcoind.service`):


### PR DESCRIPTION
Since Eclair Mobile now has a full feature set, there's been some extra interest in electrs since Eclair allows user-elected electrum servers.

I've had a few people reach out to me on Twitter confused as to why their Eclair Mobile won't connect to their Electrs. The reason (which isn't clear from the Eclair menu) is that Eclair denies self-signed SSL certs. So I added a section to the electrs docs on how to install certbot to get free SSL certs and modified your nginx template to use certbot certs.

Electrs is great, and it's been perfect for the new Eclair Mobile I've been using.