### PR TITLE
Fix interrupt typo

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,7 @@ error_chain! {
 
         Interrupt(signal: Signal) {
             description("Interruption by external signal")
-            display("Iterrupted by SIG{:?}", signal)
+            display("Interrupted by SIG{:?}", signal)
         }
     }
 }


### PR DESCRIPTION
Just fixing a typo I noticed in the log output.