### PR TITLE
Update min versions for installation

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,8 +1,8 @@
 ## Installation
 
-Install [latest Rust](https://rustup.rs/) (1.28+),
+Install [latest Rust](https://rustup.rs/) (1.33+),
 [latest Bitcoin Core](https://bitcoincore.org/en/download/) (0.16+)
-and [latest Electrum wallet](https://electrum.org/#download) (3.2+).
+and [latest Electrum wallet](https://electrum.org/#download) (3.3+).
 
 Also, install the following packages (on Debian):
 ```bash


### PR DESCRIPTION
This updates the minimum version for Rust from 1.28 to the current latest which is 1.33. This is because 1.28 may fail on build due to #129.

It also updates the minimum version of Electrum to the current latest of 3.3 since version 3.2 is officially unsupported due to a known phishing vulnerability.