### PR TITLE
Add cache for block transaction IDs

### DIFF
--- a/examples/index.rs
+++ b/examples/index.rs
@@ -17,7 +17,7 @@ fn run() -> Result<()> {
     let config = Config::from_args();
     let metrics = Metrics::new(config.monitoring_addr);
     metrics.start();
-    let cache = Arc::new(BlockTxIDsCache::new(0));
+    let cache = Arc::new(BlockTxIDsCache::new(0, &metrics));
 
     let daemon = Daemon::new(
         &config.daemon_dir,

--- a/examples/index.rs
+++ b/examples/index.rs
@@ -6,16 +6,18 @@ extern crate error_chain;
 extern crate log;
 
 use electrs::{
-    config::Config, daemon::Daemon, errors::*, fake::FakeStore, index::Index, metrics::Metrics,
-    signal::Waiter,
+    cache::BlockTxIDsCache, config::Config, daemon::Daemon, errors::*, fake::FakeStore,
+    index::Index, metrics::Metrics, signal::Waiter,
 };
 use error_chain::ChainedError;
+use std::sync::Arc;
 
 fn run() -> Result<()> {
     let signal = Waiter::start();
     let config = Config::from_args();
     let metrics = Metrics::new(config.monitoring_addr);
     metrics.start();
+    let cache = Arc::new(BlockTxIDsCache::new(0));
 
     let daemon = Daemon::new(
         &config.daemon_dir,
@@ -23,6 +25,7 @@ fn run() -> Result<()> {
         config.cookie_getter(),
         config.network_type,
         signal.clone(),
+        cache,
         &metrics,
     )?;
     let fake_store = FakeStore {};

--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -28,7 +28,7 @@ fn run_server(config: &Config) -> Result<()> {
     let signal = Waiter::start();
     let metrics = Metrics::new(config.monitoring_addr);
     metrics.start();
-    let blocktxids_cache = Arc::new(BlockTxIDsCache::new(config.blocktxids_cache_size));
+    let blocktxids_cache = Arc::new(BlockTxIDsCache::new(config.blocktxids_cache_size, &metrics));
 
     let daemon = Daemon::new(
         &config.daemon_dir,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,16 +1,27 @@
 use crate::errors::*;
+use crate::metrics::{Counter, MetricOpts, Metrics};
 use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 use lru::LruCache;
 use std::sync::Mutex;
 
 pub struct BlockTxIDsCache {
     map: Mutex<LruCache<Sha256dHash /* blockhash */, Vec<Sha256dHash /* txid */>>>,
+    hits: Counter,
+    misses: Counter,
 }
 
 impl BlockTxIDsCache {
-    pub fn new(capacity: usize) -> BlockTxIDsCache {
+    pub fn new(capacity: usize, metrics: &Metrics) -> BlockTxIDsCache {
         BlockTxIDsCache {
             map: Mutex::new(LruCache::new(capacity)),
+            hits: metrics.counter(MetricOpts::new(
+                "electrs_blocktxids_cache_hits",
+                "# of cache hits for list of transactions in a block",
+            )),
+            misses: metrics.counter(MetricOpts::new(
+                "electrs_blocktxids_cache_misses",
+                "# of cache misses for list of transactions in a block",
+            )),
         }
     }
 
@@ -23,9 +34,11 @@ impl BlockTxIDsCache {
         F: FnOnce() -> Result<Vec<Sha256dHash>>,
     {
         if let Some(txids) = self.map.lock().unwrap().get(blockhash) {
+            self.hits.inc();
             return Ok(txids.clone());
         }
 
+        self.misses.inc();
         let txids = load_txids_func()?;
         self.map.lock().unwrap().put(*blockhash, txids.clone());
         Ok(txids)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,33 @@
+use crate::errors::*;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
+use lru::LruCache;
+use std::sync::Mutex;
+
+pub struct BlockTxIDsCache {
+    map: Mutex<LruCache<Sha256dHash /* blockhash */, Vec<Sha256dHash /* txid */>>>,
+}
+
+impl BlockTxIDsCache {
+    pub fn new(capacity: usize) -> BlockTxIDsCache {
+        BlockTxIDsCache {
+            map: Mutex::new(LruCache::new(capacity)),
+        }
+    }
+
+    pub fn get_or_else<F>(
+        &self,
+        blockhash: &Sha256dHash,
+        load_txids_func: F,
+    ) -> Result<Vec<Sha256dHash>>
+    where
+        F: FnOnce() -> Result<Vec<Sha256dHash>>,
+    {
+        if let Some(txids) = self.map.lock().unwrap().get(blockhash) {
+            return Ok(txids.clone());
+        }
+
+        let txids = load_txids_func()?;
+        self.map.lock().unwrap().put(*blockhash, txids.clone());
+        Ok(txids)
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub tx_cache_size: usize,
     pub txid_limit: usize,
     pub server_banner: String,
+    pub blocktxids_cache_size: usize,
 }
 
 fn str_to_socketaddr(address: &str, what: &str) -> SocketAddr {
@@ -125,6 +126,11 @@ impl Config {
                     .help("Number of transactions to keep in for query LRU cache")
                     .default_value("10000")  // should be enough for a small wallet.
             )
+            .arg(
+                Arg::with_name("blocktxids_cache_size")
+                    .long("blocktxids-cache-size")
+                    .help("Number of blocks to cache transactions IDs in LRU cache")
+                    .default_value("100")) // Needs ~0.305MB per per block at 10k txs each
             .arg(
                 Arg::with_name("txid_limit")
                     .long("txid-limit")
@@ -227,6 +233,7 @@ impl Config {
             index_batch_size: value_t_or_exit!(m, "index_batch_size", usize),
             bulk_index_threads,
             tx_cache_size: value_t_or_exit!(m, "tx_cache_size", usize),
+            blocktxids_cache_size: value_t_or_exit!(m, "blocktxids_cache_size", usize),
             txid_limit: value_t_or_exit!(m, "txid_limit", usize),
             server_banner: value_t_or_exit!(m, "server_banner", String),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate serde_json;
 
 pub mod app;
 pub mod bulk;
+pub mod cache;
 pub mod config;
 pub mod daemon;
 pub mod errors;


### PR DESCRIPTION
On cache hit, this improves performance of `blockchain.transaction.get_merkle` and thus wallet synchronization