### PR TITLE
Replace PerodicUpdate with scripthash notifications

### DIFF
--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -160,7 +160,7 @@ fn load_headers(daemon: &Daemon) -> Result<HeaderList> {
     let tip = daemon.getbestblockhash()?;
     let mut headers = HeaderList::empty();
     let new_headers = headers.order(daemon.get_new_headers(&headers, &tip)?);
-    headers.apply(new_headers, tip);
+    headers.apply(&new_headers, tip);
     Ok(headers)
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -2,10 +2,11 @@ use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::consensus::encode::{deserialize, serialize};
 use bitcoin_hashes::hex::{FromHex, ToHex};
 use bitcoin_hashes::sha256d::Hash as Sha256dHash;
+use bitcoin_hashes::Hash;
 use error_chain::ChainedError;
 use hex;
 use serde_json::{from_str, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc::{Sender, SyncSender, TrySendError};
@@ -13,8 +14,10 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use crate::errors::*;
+use crate::index::compute_script_hash;
 use crate::metrics::{Gauge, HistogramOpts, HistogramVec, MetricOpts, Metrics};
 use crate::query::{Query, Status};
+use crate::util::FullHash;
 use crate::util::{spawn_thread, Channel, HeaderEntry, SyncChannel};
 
 const ELECTRS_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -203,6 +206,9 @@ impl Connection {
         let status = self.query.status(&script_hash[..])?;
         let result = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
         self.status_hashes.insert(script_hash, result.clone());
+        self.stats
+            .subscriptions
+            .set(self.status_hashes.len() as i64);
         Ok(result)
     }
 
@@ -237,10 +243,6 @@ impl Connection {
         let tx = hex::decode(&tx).chain_err(|| "non-hex tx")?;
         let tx: Transaction = deserialize(&tx).chain_err(|| "failed to parse tx")?;
         let txid = self.query.broadcast(&tx)?;
-        self.query.update_mempool()?;
-        if let Err(e) = self.chan.sender().try_send(Message::PeriodicUpdate) {
-            warn!("failed to issue PeriodicUpdate after broadcast: {}", e);
-        }
         Ok(json!(txid.to_hex()))
     }
 
@@ -332,42 +334,63 @@ impl Connection {
         })
     }
 
-    fn update_subscriptions(&mut self) -> Result<Vec<Value>> {
+    fn on_scripthash_change(&mut self, scripthash: FullHash) -> Result<()> {
+        let scripthash = Sha256dHash::from_slice(&scripthash[..]).expect("invalid scripthash");
+
+        let old_statushash;
+        match self.status_hashes.get(&scripthash) {
+            Some(statushash) => {
+                old_statushash = statushash;
+            }
+            None => {
+                return Ok(());
+            }
+        };
+
         let timer = self
             .stats
             .latency
-            .with_label_values(&["periodic_update"])
+            .with_label_values(&["statushash_update"])
             .start_timer();
-        let mut result = vec![];
-        if let Some(ref mut last_entry) = self.last_header_entry {
-            let entry = self.query.get_best_header()?;
-            if *last_entry != entry {
-                *last_entry = entry;
-                let hex_header = hex::encode(serialize(last_entry.header()));
-                let header = json!({"hex": hex_header, "height": last_entry.height()});
-                result.push(json!({
-                    "jsonrpc": "2.0",
-                    "method": "blockchain.headers.subscribe",
-                    "params": [header]}));
-            }
-        }
-        for (script_hash, status_hash) in self.status_hashes.iter_mut() {
-            let status = self.query.status(&script_hash[..])?;
-            let new_status_hash = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
-            if new_status_hash == *status_hash {
-                continue;
-            }
-            result.push(json!({
-                "jsonrpc": "2.0",
-                "method": "blockchain.scripthash.subscribe",
-                "params": [script_hash.to_hex(), new_status_hash]}));
-            *status_hash = new_status_hash;
+
+        let status = self.query.status(&scripthash[..])?;
+        let new_statushash = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
+        if new_statushash == *old_statushash {
+            return Ok(());
         }
         timer.observe_duration();
-        self.stats
-            .subscriptions
-            .set(self.status_hashes.len() as i64);
-        Ok(result)
+        self.send_values(&vec![json!({
+                    "jsonrpc": "2.0",
+                    "method": "blockchain.scripthash.subscribe",
+                    "params": [scripthash.to_hex(), new_statushash]})])?;
+        self.status_hashes.insert(scripthash, new_statushash);
+        Ok(())
+    }
+
+    fn on_chaintip_change(&mut self, chaintip: HeaderEntry) -> Result<()> {
+        let timer = self
+            .stats
+            .latency
+            .with_label_values(&["chaintip_update"])
+            .start_timer();
+
+        if let Some(ref mut last_entry) = self.last_header_entry {
+            if *last_entry == chaintip {
+                return Ok(());
+            }
+
+            *last_entry = chaintip;
+            let hex_header = hex::encode(serialize(last_entry.header()));
+            let header = json!({"hex": hex_header, "height": last_entry.height()});
+            self.send_values(&vec![
+                (json!({
+                "jsonrpc": "2.0",
+                "method": "blockchain.headers.subscribe",
+                "params": [header]})),
+            ])?;
+        }
+        timer.observe_duration();
+        Ok(())
     }
 
     fn send_values(&mut self, values: &[Value]) -> Result<()> {
@@ -384,9 +407,9 @@ impl Connection {
         let empty_params = json!([]);
         loop {
             let msg = self.chan.receiver().recv().chain_err(|| "channel closed")?;
-            trace!("RPC {:?}", msg);
             match msg {
                 Message::Request(line) => {
+                    trace!("RPC {:?}", line);
                     let cmd: Value = from_str(&line).chain_err(|| "invalid JSON format")?;
                     let reply = match (
                         cmd.get("method"),
@@ -402,12 +425,8 @@ impl Connection {
                     };
                     self.send_values(&[reply])?
                 }
-                Message::PeriodicUpdate => {
-                    let values = self
-                        .update_subscriptions()
-                        .chain_err(|| "failed to update subscriptions")?;
-                    self.send_values(&values)?
-                }
+                Message::ScriptHashChange(hash) => self.on_scripthash_change(hash)?,
+                Message::ChainTipChange(tip) => self.on_chaintip_change(tip)?,
                 Message::Done => return Ok(()),
             }
         }
@@ -463,18 +482,21 @@ impl Connection {
 #[derive(Debug)]
 pub enum Message {
     Request(String),
-    PeriodicUpdate,
+    ScriptHashChange(FullHash),
+    ChainTipChange(HeaderEntry),
     Done,
 }
 
 pub enum Notification {
-    Periodic,
+    ScriptHashChange(FullHash),
+    ChainTipChange(HeaderEntry),
     Exit,
 }
 
 pub struct RPC {
     notification: Sender<Notification>,
     server: Option<thread::JoinHandle<()>>, // so we can join the server while dropping this ojbect
+    query: Arc<Query>,
 }
 
 struct Stats {
@@ -492,10 +514,20 @@ impl RPC {
             for msg in notification.receiver().iter() {
                 let mut senders = senders.lock().unwrap();
                 match msg {
-                    Notification::Periodic => {
+                    Notification::ScriptHashChange(hash) => {
                         for sender in senders.split_off(0) {
                             if let Err(TrySendError::Disconnected(_)) =
-                                sender.try_send(Message::PeriodicUpdate)
+                                sender.try_send(Message::ScriptHashChange(hash))
+                            {
+                                continue;
+                            }
+                            senders.push(sender);
+                        }
+                    }
+                    Notification::ChainTipChange(hash) => {
+                        for sender in senders.split_off(0) {
+                            if let Err(TrySendError::Disconnected(_)) =
+                                sender.try_send(Message::ChainTipChange(hash.clone()))
                             {
                                 continue;
                             }
@@ -543,6 +575,7 @@ impl RPC {
         let notification = Channel::unbounded();
         RPC {
             notification: notification.sender(),
+            query: query.clone(),
             server: Some(spawn_thread("rpc", move || {
                 let senders = Arc::new(Mutex::new(Vec::<SyncSender<Message>>::new()));
                 let acceptor = RPC::start_acceptor(addr);
@@ -573,8 +606,105 @@ impl RPC {
         }
     }
 
-    pub fn notify(&self) {
-        self.notification.send(Notification::Periodic).unwrap();
+    /// Attempt to notify scripthash subscriptions affected by transaction.
+    /// The `notified` hashset is an optimization to avoid double notifications.
+    /// When `notify_inputs` is set, we also notify scripthashes that are spent from.
+    fn try_notify_subscriptions_for_tx(
+        &self,
+        txid: &Sha256dHash,
+        mut blockhash: Option<Sha256dHash>,
+        notified: &mut HashSet<Sha256dHash>,
+        notify_inputs: bool,
+    ) -> Result<()> {
+        if notified.contains(txid) {
+            return Ok(());
+        }
+        notified.insert(txid.clone());
+
+        if blockhash.is_none() {
+            match self.query.lookup_confirmed_blockhash(txid, None) {
+                Ok(hash) => blockhash = hash,
+                Err(err) => trace!("Failed to lookup blockhash for {}: {}", txid, err),
+            };
+        }
+
+        let txn = self.query.load_txn(txid, blockhash)?;
+
+        let scripthashes: Vec<FullHash> = txn
+            .output
+            .iter()
+            .map(|o| compute_script_hash(&o.script_pubkey[..]))
+            .collect();
+
+        for s in scripthashes {
+            if let Err(e) = self.notification.send(Notification::ScriptHashChange(s)) {
+                trace!("ScriptHash change notification failed {}", e);
+            }
+        }
+
+        if notify_inputs {
+            for txin in txn.input {
+                if txin.previous_output.is_null() {
+                    continue;
+                }
+                let id: &Sha256dHash = &txin.previous_output.txid;
+
+                if let Err(e) = self.try_notify_subscriptions_for_tx(id, None, notified, false) {
+                    trace!("failed to load input transaction {}: {}", id, e);
+                    continue;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn notify_scripthash_subscriptions(
+        &self,
+        headers_changed: &Vec<HeaderEntry>,
+        txs_changed: HashSet<Sha256dHash>,
+    ) {
+        // Keep track of which txs have been notified, so we don't spend time
+        // notifying them twice.
+        let mut notified: HashSet<Sha256dHash> = HashSet::new();
+
+        for txid in txs_changed {
+            if let Err(e) = self.try_notify_subscriptions_for_tx(&txid, None, &mut notified, true) {
+                trace!("Failed notifying subscriptions {}", e);
+            }
+        }
+
+        for header in headers_changed {
+            let blockhash = header.hash();
+            let res = self.query.with_blocktxids(&blockhash, |txid| {
+                if let Err(e) = self.try_notify_subscriptions_for_tx(
+                    &txid,
+                    Some(*blockhash),
+                    &mut notified,
+                    true,
+                ) {
+                    trace!("Failed notifying subscriptions {}", e);
+                    return;
+                }
+            });
+            if let Err(e) = res {
+                trace!(
+                    "Failed to fetch transactions for block {}: {}",
+                    blockhash,
+                    e
+                );
+            }
+        }
+    }
+
+    pub fn notify_subscriptions_chaintip(&self, header: HeaderEntry) {
+        if let Err(e) = self.notification.send(Notification::ChainTipChange(header)) {
+            trace!("Failed to notify about chaintip change {}", e);
+        }
+    }
+
+    pub fn disconnect_clients(&self) {
+        trace!("disconncting clients");
+        self.notification.send(Notification::Exit).unwrap();
     }
 }
 


### PR DESCRIPTION
This removes the expensive `PeriodicUpdate` call from the application loop.

`PeriodicUpdate` would iterate through every subscription of every connected client and re-calculate its status to look for differences.

The new code calculates which subscription need update and notifies each RPC connection. If, and only if, a client is subscribed will it re-calculate its status.

To test performance, I have written [this benchmark script](https://github.com/BitcoinUnlimited/ElectrsCash/blob/master/contrib/bench/server-compare.js).

***Before this PR - DEBUG***
```
Connecting to  [ 60001, 'localhost', 'tcp' ]
* 2000x blockchain.scripthash.subscribe localhost(39.844 s)
* 2000x blockchain.scripthash.subscribe localhost(40.851 s)
* 2000x blockchain.scripthash.subscribe localhost(41.886 s)
* 2000x blockchain.scripthash.subscribe localhost(41.982 s)
* 2000x blockchain.scripthash.subscribe localhost(41.753 s)
* 2000x blockchain.scripthash.subscribe localhost(41.950 s)
* 2000x blockchain.scripthash.subscribe localhost(42.162 s)
* 2000x blockchain.scripthash.subscribe localhost(41.867 s)
* 2000x blockchain.scripthash.subscribe localhost(42.210 s)
* 2000x blockchain.scripthash.subscribe localhost(42.504 s)
```

***This PR - DEBUG***
```
Connecting to  [ 60001, 'localhost', 'tcp' ]
* 2000x blockchain.scripthash.subscribe localhost(35.505 s)
* 2000x blockchain.scripthash.subscribe localhost(16.546 s)
* 2000x blockchain.scripthash.subscribe localhost(16.571 s)
* 2000x blockchain.scripthash.subscribe localhost(16.538 s)
* 2000x blockchain.scripthash.subscribe localhost(16.570 s)
* 2000x blockchain.scripthash.subscribe localhost(16.523 s)
* 2000x blockchain.scripthash.subscribe localhost(16.529 s)
* 2000x blockchain.scripthash.subscribe localhost(16.523 s)
* 2000x blockchain.scripthash.subscribe localhost(16.595 s)
* 2000x blockchain.scripthash.subscribe localhost(16.535 s)
```

***Before this PR - RELEASE***
```
Connecting to  [ 60001, 'localhost', 'tcp' ]
* 2000x blockchain.scripthash.subscribe localhost(23.008 s)
* 2000x blockchain.scripthash.subscribe localhost(4.692 s)
* 2000x blockchain.scripthash.subscribe localhost(4.708 s)
* 2000x blockchain.scripthash.subscribe localhost(4.653 s)
* 2000x blockchain.scripthash.subscribe localhost(4.665 s)
* 2000x blockchain.scripthash.subscribe localhost(4.689 s)
* 2000x blockchain.scripthash.subscribe localhost(4.713 s)
* 2000x blockchain.scripthash.subscribe localhost(4.689 s)
* 2000x blockchain.scripthash.subscribe localhost(4.680 s)
* 2000x blockchain.scripthash.subscribe localhost(4.674 s)
```

***This PR - RELEASE***
```
Connecting to  [ 60001, 'localhost', 'tcp' ]
* 2000x blockchain.scripthash.subscribe localhost(21.723 s)
* 2000x blockchain.scripthash.subscribe localhost(3.604 s)
* 2000x blockchain.scripthash.subscribe localhost(3.593 s)
* 2000x blockchain.scripthash.subscribe localhost(3.618 s)
* 2000x blockchain.scripthash.subscribe localhost(3.614 s)
* 2000x blockchain.scripthash.subscribe localhost(3.613 s)
* 2000x blockchain.scripthash.subscribe localhost(3.608 s)
* 2000x blockchain.scripthash.subscribe localhost(3.611 s)
* 2000x blockchain.scripthash.subscribe localhost(3.621 s)
* 2000x blockchain.scripthash.subscribe localhost(3.616 s)
```

To test correctness I have written [this integration test](https://github.com/BitcoinUnlimited/BitcoinUnlimited/commit/73c5e4be01e0ae39080e3fcb1cf6f17fbd9c2583), but to port it to this repository https://github.com/romanz/electrs/issues/168 needs to be solved.

