### PR TITLE
Scale script hashes subscriptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: rust
 
-arch:
-  - amd64
-  - arm64
-
 rust:
   - stable
 

--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -8,21 +8,25 @@ use error_chain::ChainedError;
 use std::process;
 use std::sync::Arc;
 use std::time::Duration;
+use std::collections::HashSet;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
+use bitcoin_hashes::Hash;
 
 use electrs::{
     app::App,
     bulk,
     cache::{BlockTxIDsCache, TransactionCache},
     config::Config,
-    daemon::Daemon,
+    daemon::{Daemon, tx_from_value},
     errors::*,
-    index::Index,
+    index::{Index, compute_script_hash},
     metrics::Metrics,
     query::Query,
     rpc::RPC,
     signal::Waiter,
     store::{full_compaction, is_fully_compacted, DBStore},
 };
+use bitcoin::Transaction;
 
 fn run_server(config: &Config) -> Result<()> {
     let signal = Waiter::start();
@@ -63,8 +67,10 @@ fn run_server(config: &Config) -> Result<()> {
 
     let mut server = None; // Electrum RPC server
     loop {
-        app.update(&signal)?;
-        query.update_mempool()?;
+        let new_block_headers = app.update(&signal)?;
+        let new_mempool_txs = query.update_mempool()?;
+        let script_hashes = get_script_hashes_in_blocks(app.daemon(), &query,new_block_headers)?
+            .extend(get_script_hashes_in_mempool_txs(app.daemon(), &query, new_mempool_txs)?);
         server
             .get_or_insert_with(|| RPC::start(config.electrum_rpc_addr, query.clone(), &metrics))
             .notify(); // update subscribed clients
@@ -74,6 +80,84 @@ fn run_server(config: &Config) -> Result<()> {
         }
     }
     Ok(())
+}
+
+
+fn get_script_hashes_in_blocks(daemon: &Daemon, query: &Arc<Query>, block_hashes: Vec<Sha256dHash>) -> Result<HashSet<Sha256dHash>> {
+    let mut script_hashes = HashSet::<Sha256dHash>::new();
+    let blocks = daemon.getblocks(block_hashes.as_ref())?;
+    for block in blocks {
+        for tx in block.txdata {
+            if tx.is_coin_base() {
+                continue;
+            }
+
+            // for each script_hash in tx.inputs
+            for input in tx.input.iter() {
+                // find output, get the relevant script hash in it
+                let previous_output_tx = tx_from_value(
+                    query.get_transaction(&input.previous_output.txid, false)?)?;
+                let previous_output = previous_output_tx.output.get(input.previous_output.vout as usize)
+                    .chain_err(|| format!("failed finding previous output {}:{}", input.previous_output.txid, input.previous_output.vout))?;
+                let script_hash =
+                    Sha256dHash::from_slice(&compute_script_hash(&previous_output.script_pubkey[..]))
+                        .expect("failed computing script hash for output.script_pubkey");
+                // if script_hash in self.script_hashes, add to the relevant script hashes list
+                script_hashes.insert(script_hash);
+            }
+
+            for (i, output) in tx.output.iter().enumerate() {
+                let script_hash =
+                    Sha256dHash::from_slice(&compute_script_hash(&output.script_pubkey[..]))
+                        .expect(&format!("failed computing script hash for output {}:{}", tx.txid(), i));
+                // if script_hash in self.script_hashes:
+                script_hashes.insert(script_hash);
+            }
+        }
+    }
+
+    Ok(script_hashes)
+}
+
+fn get_script_hashes_in_mempool_txs(daemon: &Daemon, query: &Arc<Query>, txs: Vec<Transaction>) -> Result<HashSet<Sha256dHash>> {
+    let mut script_hashes: HashSet<Sha256dHash> = HashSet::<Sha256dHash>::new();
+    for tx in txs {
+        for input in tx.input.iter() {
+            // find output, get the relevant script hash in it
+            let previous_output = daemon.get_confirmed_utxo(&input.previous_output.txid, input.previous_output.vout)
+                .or_else(|_e| {
+                    // possibly failed because previous output's transaction itself is unconfirmed, so search in mempool.
+                    debug!("failed to find a confirmed previous output {}:{}", &input.previous_output.txid, &input.previous_output.vout);
+                    let previous_output_tx: Transaction = query.tracker().read().unwrap()
+                        .get_txn(&input.previous_output.txid)
+                        .chain_err(|| format!("failed to find unconfirmed previous output tx {}:{}",
+                            &input.previous_output.txid, &input.previous_output.vout))?;
+
+                    previous_output_tx.output.get(input.previous_output.vout as usize)
+                        .map(|output| output.clone())
+                        .chain_err(|| format!("failed to find previous output index in tx {}:{}",
+                            &input.previous_output.txid, &input.previous_output.vout))
+                })
+                .expect(&format!("failed to get previous output {}:{}", &input.previous_output.txid, &input.previous_output.vout));
+
+            let script_hash =
+                Sha256dHash::from_slice(&compute_script_hash(&previous_output.script_pubkey[..]))
+                    .expect(&format!("failed computing script hash of previous output {}:{}",
+                        &input.previous_output.txid, &input.previous_output.vout));
+
+            script_hashes.insert(script_hash);
+        }
+
+        for (i, output) in tx.output.iter().enumerate() {
+            let script_hash =
+                Sha256dHash::from_slice(&compute_script_hash(&output.script_pubkey[..]))
+                    .expect(&format!("failed computing script hash for output {}:{}", tx.txid(), i));
+
+            script_hashes.insert(script_hash);
+        }
+    }
+
+    Ok(script_hashes)
 }
 
 fn main() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,7 +1,7 @@
 use base64;
 use bitcoin::blockdata::block::{Block, BlockHeader};
-use bitcoin::blockdata::transaction::{Transaction, TxOut};
 use bitcoin::blockdata::script::Script;
+use bitcoin::blockdata::transaction::{Transaction, TxOut};
 use bitcoin::consensus::encode::{deserialize, serialize};
 use bitcoin::network::constants::Network;
 use bitcoin::util::hash::BitcoinHash;
@@ -59,26 +59,29 @@ pub fn tx_from_value(value: Value) -> Result<Transaction> {
 fn txout_from_value(value: Value) -> Result<TxOut> {
     let txout_obj: &Map<String, Value> = value.as_object().chain_err(|| "non-object txout")?;
 
-    let script_pubkey_obj = txout_obj.get("scriptPubKey")
-        .chain_err(||"no 'scriptPubKey' key in txout")?
+    let script_pubkey_obj = txout_obj
+        .get("scriptPubKey")
+        .chain_err(|| "no 'scriptPubKey' key in txout")?
         .as_object()
-        .chain_err(||"non-object 'scriptPubKey' value in txout")?;
-    let txout_hex = script_pubkey_obj.get("hex")
-        .chain_err(||"no 'hex' key in txout")?
+        .chain_err(|| "non-object 'scriptPubKey' value in txout")?;
+    let txout_hex = script_pubkey_obj
+        .get("hex")
+        .chain_err(|| "no 'hex' key in txout")?
         .as_str()
-        .chain_err(||"non-string 'hex' value in script_pubkey_obj")?;
+        .chain_err(|| "non-string 'hex' value in script_pubkey_obj")?;
     let txout_bytes = hex::decode(txout_hex).chain_err(|| "non-hex txout")?;
     let script_pubkey = Script::from(txout_bytes);
 
-    let value = (txout_obj.get("value")
-        .chain_err(||"no 'value' key in txout")?
+    let value = (txout_obj
+        .get("value")
+        .chain_err(|| "no 'value' key in txout")?
         .as_f64()
-        .chain_err(||"non-u64 'value' value in txout")?
+        .chain_err(|| "non-u64 'value' value in txout")?
         * 100_000_000f64) as u64;
 
     Ok(TxOut {
         value,
-        script_pubkey
+        script_pubkey,
     })
 }
 
@@ -545,12 +548,8 @@ impl Daemon {
     }
 
     // get a confirmed output which is either unspent or spent by a mempool transaction
-    pub fn get_confirmed_utxo(
-        &self,
-        txhash: &Sha256dHash,
-        n: u32,
-    ) -> Result<TxOut> {
-        let include_mempool = false;  // allow finding outputs which are spent by a mempool transaction
+    pub fn get_confirmed_utxo(&self, txhash: &Sha256dHash, n: u32) -> Result<TxOut> {
+        let include_mempool = false; // allow finding outputs which are spent by a mempool transaction
         let args = json!([txhash.to_hex(), n, include_mempool]);
         txout_from_value(self.request("gettxout", args)?)
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -372,10 +372,7 @@ impl Query {
 
     // Internal API for transaction retrieval
     fn load_txn(&self, txid: &Sha256dHash, block_height: Option<u32>) -> Result<Transaction> {
-        let _timer = self
-            .duration
-            .with_label_values(&["load_txn"])
-            .start_timer();
+        let _timer = self.duration.with_label_values(&["load_txn"]).start_timer();
         self.tx_cache.get_or_else(&txid, || {
             let blockhash = self.lookup_confirmed_blockhash(txid, block_height)?;
             let value: Value = self

--- a/src/query.rs
+++ b/src/query.rs
@@ -489,7 +489,7 @@ impl Query {
         self.app.daemon().broadcast(txn)
     }
 
-    pub fn update_mempool(&self) -> Result<()> {
+    pub fn update_mempool(&self) -> Result<Vec<Transaction>> {
         let _timer = self
             .duration
             .with_label_values(&["update_mempool"])
@@ -519,5 +519,9 @@ impl Query {
 
     pub fn get_banner(&self) -> Result<String> {
         self.app.get_banner()
+    }
+
+    pub fn tracker(&self) -> &RwLock<Tracker> {
+        &self.tracker
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -531,17 +531,17 @@ impl Query {
                     continue;
                 }
 
-                // for each script_hash in tx.inputs
                 for input in tx.input.iter() {
-                    // find output, get the relevant script hash in it
                     let previous_output_tx = tx_from_value(
                         self.get_transaction(&input.previous_output.txid, false)?)?;
+
                     let previous_output = previous_output_tx.output.get(input.previous_output.vout as usize)
                         .chain_err(|| format!("failed finding previous output {}:{}", input.previous_output.txid, input.previous_output.vout))?;
+
                     let script_hash =
                         Sha256dHash::from_slice(&compute_script_hash(&previous_output.script_pubkey[..]))
                             .expect("failed computing script hash for output.script_pubkey");
-                    // if script_hash in self.script_hashes, add to the relevant script hashes list
+
                     script_hashes.insert(script_hash);
                 }
 
@@ -549,7 +549,7 @@ impl Query {
                     let script_hash =
                         Sha256dHash::from_slice(&compute_script_hash(&output.script_pubkey[..]))
                             .expect(&format!("failed computing script hash for output {}:{}", tx.txid(), i));
-                    // if script_hash in self.script_hashes:
+
                     script_hashes.insert(script_hash);
                 }
             }
@@ -562,7 +562,6 @@ impl Query {
         let mut script_hashes = HashSet::<Sha256dHash>::new();
         for tx in txs {
             for input in tx.input.iter() {
-                // find output, get the relevant script hash in it
                 let previous_output = self.app.daemon().get_confirmed_utxo(&input.previous_output.txid, input.previous_output.vout)
                     .or_else(|_e| {
                         // possibly failed because previous output's transaction itself is unconfirmed, so search in mempool.
@@ -570,19 +569,19 @@ impl Query {
                         let previous_output_tx = self.tracker.read().unwrap()
                             .get_txn(&input.previous_output.txid)
                             .chain_err(|| format!("failed to find unconfirmed previous output tx {}:{}",
-                                                  &input.previous_output.txid, &input.previous_output.vout))?;
+                                &input.previous_output.txid, &input.previous_output.vout))?;
 
                         previous_output_tx.output.get(input.previous_output.vout as usize)
                             .map(|output| output.clone())
                             .chain_err(|| format!("failed to find previous output index in tx {}:{}",
-                                                  &input.previous_output.txid, &input.previous_output.vout))
+                                &input.previous_output.txid, &input.previous_output.vout))
                     })
                     .expect(&format!("failed to get previous output {}:{}", &input.previous_output.txid, &input.previous_output.vout));
 
                 let script_hash =
                     Sha256dHash::from_slice(&compute_script_hash(&previous_output.script_pubkey[..]))
                         .expect(&format!("failed computing script hash of previous output {}:{}",
-                                         &input.previous_output.txid, &input.previous_output.vout));
+                            &input.previous_output.txid, &input.previous_output.vout));
 
                 script_hashes.insert(script_hash);
             }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -239,7 +239,11 @@ impl Connection {
         let txid = self.query.broadcast(&tx)?;
         let mempool_txs = self.query.update_mempool()?;
         let script_hashes = self.query.get_script_hashes_in_mempool_txs(mempool_txs)?;
-        if let Err(e) = self.chan.sender().try_send(Message::PeriodicUpdate(script_hashes)) {
+        if let Err(e) = self
+            .chan
+            .sender()
+            .try_send(Message::PeriodicUpdate(script_hashes))
+        {
             warn!("failed to issue PeriodicUpdate after broadcast: {}", e);
         }
         Ok(json!(txid.to_hex()))
@@ -333,7 +337,10 @@ impl Connection {
         })
     }
 
-    fn update_subscriptions(&mut self, new_txs_script_hashes: HashSet<Sha256dHash>) -> Result<Vec<Value>> {
+    fn update_subscriptions(
+        &mut self,
+        new_txs_script_hashes: HashSet<Sha256dHash>,
+    ) -> Result<Vec<Value>> {
         let timer = self
             .stats
             .latency
@@ -353,8 +360,12 @@ impl Connection {
             }
         }
 
-        let subscribed_script_hashes: HashSet<Sha256dHash> = self.status_hashes.keys().map(|k| *k).collect();
-        let subscribed_script_hashes_in_new_txs: Vec<Sha256dHash> = new_txs_script_hashes.intersection(&subscribed_script_hashes).map(|s| *s).collect();
+        let subscribed_script_hashes: HashSet<Sha256dHash> =
+            self.status_hashes.keys().map(|k| *k).collect();
+        let subscribed_script_hashes_in_new_txs: Vec<Sha256dHash> = new_txs_script_hashes
+            .intersection(&subscribed_script_hashes)
+            .map(|s| *s)
+            .collect();
         for script_hash in subscribed_script_hashes_in_new_txs.iter() {
             let status_hash = self.status_hashes.get_mut(script_hash).unwrap();
             let status = self.query.status(&script_hash[..])?;
@@ -579,7 +590,9 @@ impl RPC {
     }
 
     pub fn notify(&self, script_hashes: HashSet<Sha256dHash>) {
-        self.notification.send(Notification::Periodic(script_hashes)).unwrap();
+        self.notification
+            .send(Notification::Periodic(script_hashes))
+            .unwrap();
     }
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -496,7 +496,7 @@ pub enum Message {
 }
 
 pub enum Notification {
-    Periodic,
+    NewTransactions,
     Exit,
 }
 


### PR DESCRIPTION
Relates to issue #146.

Main idea - 
1) Only upon a new batch of mempool transactions or a new block, the mempool tracker and blockchain poller (respectively) will parse the participating addresses in the new transactions.
2) The list of participating addresses will be passed to each Connection.
3) Each Connection will filter and query the status only of its subscribed addresses which participated in this recent batch of transactions.

What was before:
Every n seconds each connection would query the status of **all** its subscribed addresses.

This PR would limit the number of operations in every periodic lookup to be in the order of __new transactions in this period of time__, instead of the order of __subscribed addresses__.