### PR TITLE
Correct --network arg values in the doc

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -47,7 +47,7 @@ doc = "JSONRPC authentication cookie file (default: ~/.bitcoin/.cookie)"
 name = "network"
 type = "crate::config::BitcoinNetwork"
 convert_into = "::bitcoin::network::constants::Network"
-doc = "Select Bitcoin network type ('mainnet', 'testnet' or 'regtest')"
+doc = "Select Bitcoin network type ('bitcoin', 'testnet' or 'regtest')"
 default = "Default::default()"
 
 [[param]]


### PR DESCRIPTION
After a recent switch to configure_me in ec049b9a, the 'mainnet'
arg value became 'bitcoin'. 2c50791d then updated db dir location
but the doc for the --network arg remained stale.

An alternative is to accept both 'mainnet' and 'bitcoin' but
it would be confusing IMHO.