### PR TITLE
split_off channged to retain

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -497,14 +497,15 @@ impl RPC {
                 let mut senders = senders.lock().unwrap();
                 match msg {
                     Notification::Periodic => {
-                        for sender in senders.split_off(0) {
+                        senders.retain(|sender| {
                             if let Err(TrySendError::Disconnected(_)) =
                                 sender.try_send(Message::PeriodicUpdate)
                             {
-                                continue;
+                                false
+                            } else {
+                                true
                             }
-                            senders.push(sender);
-                        }
+                        })
                     }
                     Notification::Exit => acceptor.send(None).unwrap(), // mark acceptor as done
                 }


### PR DESCRIPTION
This changes `split_off`, which does one allocation and copies `n` items
in the best case, `2 * n` items in the worst case to `retain`, which does
zero allocations and copies zero items in the best case and `3 * (n - 1)`
items in worst case (because swap is 3 copies and `retain` has to swap
due to possibility of panic).

I believe this should be net-benefit due to usually small `n`.

**Disclaimer**: didn't have time to test, but it looks obvious enough. :)