### PR TITLE
Base Docker image on debian:buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,24 @@
-FROM rust:1.34.0-slim
+FROM debian:buster-slim
 
 RUN apt-get update
 RUN apt-get install -y clang cmake
 RUN apt-get install -y libsnappy-dev
+RUN apt-get install -y curl
 
 RUN adduser --disabled-login --system --shell /bin/false --uid 1000 user
+
+ARG RUST_VERSION=1.34.0
+ENV RUSTUP_HOME /usr/local/rustup
+ENV CARGO_HOME /usr/local/cargo
+ENV PATH $CARGO_HOME/bin:$PATH
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
+  -y \
+  --verbose \
+  --profile minimal \
+  --default-toolchain $RUST_VERSION
+
+RUN chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
 USER user
 WORKDIR /home/user


### PR DESCRIPTION
Resolves #226.

The current Docker image has a strange bug when being built on 32 bit ARM devices causing RocksDB to be built incorrectly and `electrs` to exit as soon as it's started.

Updating to Debian Buster seems to fix the bug somewhere in the C++ toolchain. There is no official Buster Docker image for Rust 1.34.0 so instead I've used Debian Buster as the base image and manually installed Rust 1.34.0.

I've also added `RUST_VERSION` as a build arg which is passed through to `rustup`.

This means the image easily be changed to support any Rust version supported by `rustup` at build time by passing in a build arg or by changing the default in the Dockerfile.

e.g:
```
# Builds with Rust 1.34.0 by default
$ docker build -t electrs .

# Manually specify a Rust version
$ docker build -t electrs --build-arg RUST_VERSION=1.40.0 .

# Use the latest stable Rust version
$ docker build -t electrs --build-arg RUST_VERSION=stable .
```