### PR TITLE
Add a `blocks_dir` option analogous to bitcoind's `-blocksdir`

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -30,6 +30,11 @@ doc = "Data directory of Bitcoind (default: ~/.bitcoin/)"
 default = "crate::config::default_daemon_dir()"
 
 [[param]]
+name = "blocks_dir"
+type = "std::path::PathBuf"
+doc = "Analogous to bitcoind's -blocksdir option, this specifies the directory containing the raw blocks files (blk*.dat)"
+
+[[param]]
 name = "cookie"
 type = "String"
 doc = "JSONRPC authentication cookie ('USER:PASSWORD', default: read from cookie file)"

--- a/examples/index.rs
+++ b/examples/index.rs
@@ -21,6 +21,7 @@ fn run() -> Result<()> {
 
     let daemon = Daemon::new(
         &config.daemon_dir,
+        &config.blocks_dir,
         config.daemon_rpc_addr,
         config.cookie_getter(),
         config.network_type,

--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -31,6 +31,7 @@ fn run_server(config: &Config) -> Result<()> {
 
     let daemon = Daemon::new(
         &config.daemon_dir,
+        &config.blocks_dir,
         config.daemon_rpc_addr,
         config.cookie_getter(),
         config.network_type,

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,7 @@ pub struct Config {
     pub network_type: Network,
     pub db_path: PathBuf,
     pub daemon_dir: PathBuf,
+    pub blocks_dir: PathBuf,
     pub daemon_rpc_addr: SocketAddr,
     pub electrum_rpc_addr: SocketAddr,
     pub monitoring_addr: SocketAddr,
@@ -150,6 +151,10 @@ fn default_daemon_dir() -> PathBuf {
     });
     home.push(".bitcoin");
     home
+}
+
+fn default_blocks_dir(daemon_dir: &Path) -> PathBuf {
+    daemon_dir.join("blocks")
 }
 
 fn create_cookie_getter(
@@ -230,6 +235,10 @@ impl Config {
             Network::Regtest => config.daemon_dir.push("regtest"),
         }
 
+        let blocks_dir = config.blocks_dir.unwrap_or(
+            default_blocks_dir(&config.daemon_dir)
+        );
+
         let cookie_getter =
             create_cookie_getter(config.cookie, config.cookie_file, &config.daemon_dir);
 
@@ -260,6 +269,7 @@ impl Config {
             network_type: config.network,
             db_path: config.db_dir,
             daemon_dir: config.daemon_dir,
+            blocks_dir,
             daemon_rpc_addr,
             electrum_rpc_addr,
             monitoring_addr,
@@ -302,6 +312,7 @@ debug_struct! { Config,
     network_type,
     db_path,
     daemon_dir,
+    blocks_dir,
     daemon_rpc_addr,
     electrum_rpc_addr,
     monitoring_addr,


### PR DESCRIPTION
I used the quite convenient `-blocksdir` option (https://github.com/bitcoin/bitcoin/pull/12653) on my `bitcoind`, but had to fall back to symlinking the `blocks/` to be able to use Electrs with `blk`s on a different disk.

This makes Electrs aware that the `blk`s might not always be in `<config_dir>/blocks/`.