### PR TITLE
docker: account for host/container permission differences

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,11 @@ RUN apt-get update \
 
 RUN adduser --disabled-login --system --shell /bin/false --uid 1000 user
 
-USER user
 WORKDIR /home/user
 COPY ./ /home/user
+RUN chown -R user .
+
+USER user
 
 RUN cargo install --path .
 


### PR DESCRIPTION
Recently when running `docker build`, I encountered a cryptic error during `electrs` compilation (something having to do with `src/bulk.rs`) that I eventually figured out had to do with file permissions. This might be because I run with `umask 077` on my host, or it might be due to some kind of host/container uid mismatch (though my host's uid is 1000...). 

Anyway, this cautionary `chown` has fixed the build for me.