### PR TITLE
Update usage.md

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -11,7 +11,7 @@ and [latest Electrum wallet](https://electrum.org/#download) (3.3+).
 Also, install the following packages (on Debian):
 ```bash
 $ sudo apt update
-$ sudo apt install clang cmake  # for building 'rust-rocksdb'
+$ sudo apt install clang cmake build-essential  # for building 'rust-rocksdb'
 ```
 
 Note for Raspberry Pi 4 owners: the old versions of OS/toolchains produce broken binaries. Make sure to use latest OS! (see #226)

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -8,7 +8,7 @@ Install [recent Rust](https://rustup.rs/) (1.41.1+, `apt install cargo` is prefe
 [latest Bitcoin Core](https://bitcoincore.org/en/download/) (0.16+)
 and [latest Electrum wallet](https://electrum.org/#download) (3.3+).
 
-Also, install the following packages (on Debian):
+Also, install the following packages (on Debian or Ubuntu):
 ```bash
 $ sudo apt update
 $ sudo apt install clang cmake build-essential  # for building 'rust-rocksdb'


### PR DESCRIPTION
For compilation of electrs to work in Ubuntu 20.04 build-essential package needs to be installed.