### PR TITLE
Make rocksdb compression algos optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ spec = "config_spec.toml"
 [profile.release]
 lto = true
 
+[features]
+default = ["rocksdb/snappy", "rocksdb/lz4", "rocksdb/zstd", "rocksdb/zlib", "rocksdb/bzip2"]
+
 [dependencies]
 base64 = "0.10"
 bincode = "1.0"
@@ -36,7 +39,7 @@ num_cpus = "1.0"
 page_size = "0.4"
 prometheus = "0.5"
 protobuf = "= 2.14.0"   # https://github.com/stepancheg/rust-protobuf/blob/master/CHANGELOG.md#2150---2020-06-21
-rocksdb = "= 0.12.2"	# due to https://github.com/romanz/electrs/issues/193
+rocksdb = { version = "0.12.2", default-features = false } # due to https://github.com/romanz/electrs/issues/193
 rust-crypto = "0.2"
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
This makes the compression algorithms optional, but on by default to
keep the behavior. While one might think this just decreases the size a
bit, it has another advantage: when linking with system library it's not
needed to specify the paths of all these libraries because they are already
compiled in the system library.

Note: I have WIP update of the docs that will explain how to link to system
libraries, including with cross-compiling, I'm just waiting for some backport in
`bindgen`.