### PR TITLE
Run `cargo install` with  `--locked` in `Dockerfile`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,10 +28,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --all
+          args: --locked --release --all
 
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --all
+          args: --locked --release --all

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN chown -R user .
 
 USER user
 
-RUN cargo install --path .
+RUN cargo install --locked --path .
 
 # Electrum RPC
 EXPOSE 50001


### PR DESCRIPTION
This prevents `cargo` from changing the dependencies during build.

Closes #329