### PR TITLE
Added issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,52 @@
+---
+name: Bug report
+about: Generic bug report
+title: 'Bug:'
+labels: bug
+assignees: ''
+
+---
+
+<!--
+	If you use electrs integrated into other project report the bug to their project
+	(unless you are the project author who found the bug is in electrs itself)!
+	If electrs is crashing due to low memory try with jsonrpc-import first!
+-->
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Configure and start electrs
+2. Connect with electrum client XYZ
+3. Wait
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Configuration**
+<!-- repeat the whole details block if you use multiple config files -->
+
+<details>
+<summary>electrs.toml</summary>
+
+```
+type error message here
+```
+
+</details>
+
+Environment variables: `ELECTRS_X=Y;...`
+Arguments: `--foo`
+
+**System running electrs**
+ - Deployment method: manual/native OS package/Docker
+ - OS name and version (name of distribution and version in case of Linux)
+
+**Electrum client**
+Client name (if not upstream desktop Electrum) and version:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/build_problem.md
+++ b/.github/ISSUE_TEMPLATE/build_problem.md
@@ -1,0 +1,44 @@
+---
+name: Build problem
+about: Building of electrs failed
+title: 'Build:'
+labels: bug, build
+assignees: Kixunil
+
+---
+
+<!-- If your build died with SIGKILL, try clearing up some RAM.
+If you have a low-memory device (such as RPi) try cross-compilation first. -->
+
+**Have you read the documentation?**
+Yes. (Please, read usage.md first if you did not.)
+
+**Did you double-check that you installed all dependencies?**
+Yes. (Please, double check the dependencies if you didn't.)
+
+**Which command failed?**
+`cargo build`
+
+**What was the error message?**
+
+<details>
+<summary>Error message</summary>
+
+```
+type error message here
+```
+
+</details>
+
+**System**
+OS name and version: (If Linux, the distribution name and version)
+rustc version: (run `rustc --version`)
+cargo version: (run `cargo --version`; not guaranteed to be same as rustc version!)
+
+**Compilation**
+Linking: static/dynamic
+Cross compilation: yes/no
+Target architecture: (uname -m on Linux if not cross-compiling)
+
+**Aditional context**
+Any additional information that seems to be relevant.

--- a/.github/ISSUE_TEMPLATE/config_problem.md
+++ b/.github/ISSUE_TEMPLATE/config_problem.md
@@ -1,0 +1,37 @@
+---
+name: Configuration problem
+about: The configuration behaves unexpectedly
+title: 'Config:'
+labels: bug 
+assignees: Kixunil
+
+---
+
+<!-- If you're inexperienced with service configuration consider using automated options such as https://deb.ln-ask.me -->
+
+**Have you read the documentation?**
+Yes. (Please, read usage.md first if you did not.)
+
+**How did you configure electrs?**
+
+<!-- repeat the whole details block if you use multiple config files -->
+
+<details>
+<summary>electrs.toml</summary>
+
+```
+type error message here
+```
+
+</details>
+
+Environment variables: `ELECTRS_X=Y;...`
+Arguments: `--foo`
+
+**Debug output of configuration**
+```
+Enter the debug output of configuration shown at start of electrs
+```
+
+**Expected behavior**
+How did you expect `electrs` to be configured

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Generic feature request
+title: 'Feature:'
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This adds four GitHub issue templates with these properties:

* Nudge people to read the docs
* Nudge inexperienced people to use automation
* Nudge people to provide important information (env, logs...)
* Assign myself (Kixunil) in case of build and config issues