### PR TITLE
Add integration tests to CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .*
 _*
+contrib
 db
 dist
 doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,41 +1,15 @@
-name: electrs CI
+name: electrs
 
 on: [push, pull_request]
 
 jobs:
   electrs:
-    name: electrs
+    name: Electrum Integration Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Install
-        uses: actions-rs/toolchain@v1
-        with:
-          components: rustfmt, clippy
-          profile: minimal
-          override: true
-
-      - name: Format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all
-
+        run: docker build . --rm -t electrs:tests
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --all
-
-      - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+        run: docker run -v $PWD/contrib/:/contrib -v $PWD/tests/:/tests --rm electrs:tests bash /tests/run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ _*/
 .env
 *.dat
 electrs.toml
+bin/
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,20 +32,24 @@ RUN ./configure --disable-tests --disable-wallet --disable-bench --without-gui -
 RUN make -j"$(($(nproc)+1))"
 
 FROM updated as result
-### Electrum ###
-# Download latest Electrum wallet and a few test tools
-RUN apt-get install -qqy wget libsecp256k1-0 python3-cryptography jq netcat
-ARG ELECTRUM_VERSION=4.0.6
-WORKDIR /build/electrum
-RUN wget -q https://download.electrum.org/$ELECTRUM_VERSION/Electrum-$ELECTRUM_VERSION.tar.gz \
-&& (echo "4d90047060aaa717184e7c32b538ebf74948b6e00ab6260ab4388f07c4b9e86a Electrum-$ELECTRUM_VERSION.tar.gz" | sha256sum -c -)
-# Unpack Electrum and install it
-RUN tar xfz Electrum-$ELECTRUM_VERSION.tar.gz && ln -s $PWD/Electrum-$ELECTRUM_VERSION/run_electrum /usr/bin/electrum
-RUN electrum version --offline
-
 # Copy the binaries
-RUN apt-get install -qqy jq netcat
 COPY --from=electrs-build /usr/local/cargo/bin/electrs_rpc /usr/bin/electrs
 COPY --from=bitcoin-build /build/bitcoin/src/bitcoind /build/bitcoin/src/bitcoin-cli /usr/bin/
 RUN bitcoind -version && bitcoin-cli -version
+
+### Electrum ###
+# Download latest Electrum wallet and a few test tools
+RUN apt-get install -qqy wget libsecp256k1-0 python3-cryptography jq netcat gnupg
+ARG ELECTRUM_VERSION=4.0.6
+
+WORKDIR /build/electrum
+
+RUN wget -q https://download.electrum.org/$ELECTRUM_VERSION/Electrum-$ELECTRUM_VERSION.tar.gz && \
+	wget -q https://download.electrum.org/$ELECTRUM_VERSION/Electrum-$ELECTRUM_VERSION.tar.gz.asc && \
+	gpg --version && gpg --keyserver keyserver.ubuntu.com --recv-keys 0x6694D8DE7BE8EE5631BED9502BD5824B7F9470E6 && \
+	gpg --trusted-key 2BD5824B7F9470E6 --verify Electrum-$ELECTRUM_VERSION.tar.gz.asc Electrum-$ELECTRUM_VERSION.tar.gz
+
+# Unpack Electrum and install it
+RUN tar xfz Electrum-$ELECTRUM_VERSION.tar.gz && ln -s $PWD/Electrum-$ELECTRUM_VERSION/run_electrum /usr/bin/electrum
+RUN electrum version --offline
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,50 @@
-FROM debian:buster-slim
+FROM debian:buster-slim as updated
 RUN apt-get update
+# Install Bitcoin Core runtime dependencies
+RUN apt-get install -qqy libevent-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev
+# Install a few test tools
+RUN apt-get install -qqy jq netcat
 
-### Bitcoin ###
-
+### Bitcoin Core ###
+FROM updated as bitcoin-build
 # Buildtime dependencies
 RUN apt-get install -qqy build-essential libtool autotools-dev automake pkg-config bsdmainutils python3
-
-# Runtime dependencies
-RUN apt-get install -qqy libevent-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev
-
 # Clone source
 RUN apt-get install -qqy git
 WORKDIR /build/bitcoin
 RUN git clone --branch locations https://github.com/romanz/bitcoin.git .
 
-# Build
-RUN ./autogen.sh && ./configure --disable-wallet --without-gui --without-miniupnpc && make -j"$(($(nproc)+1))"
+# Build bitcoin
+RUN ./autogen.sh
+RUN ./configure --disable-tests --disable-wallet --disable-bench --without-gui --without-miniupnpc
+RUN make -j"$(($(nproc)+1))"
 
-# Install
-RUN mv -v src/bitcoind src/bitcoin-cli /usr/bin/
+### Electrum Rust Server ###
+FROM updated as electrs-build
+# Install Rust 1.41.1
+RUN apt-get install -qq -y clang cmake cargo rustc
 
+# Build, test and install electrs
+WORKDIR /build/electrs
+COPY . .
+RUN cargo build --locked --release --all
+RUN cargo test --locked --release --all
+
+FROM updated as result
 ### Electrum ###
-
 # Download latest Electrum wallet
 RUN apt-get install -qqy wget libsecp256k1-0 python3-cryptography
 ARG ELECTRUM_VERSION=4.0.5
 WORKDIR /build/electrum
 RUN wget -q https://download.electrum.org/$ELECTRUM_VERSION/Electrum-$ELECTRUM_VERSION.tar.gz \
 && (echo "6790407e21366186d928c8e653e3ab38476ca86e4797aa4db94dcca2384db41a Electrum-$ELECTRUM_VERSION.tar.gz" | sha256sum -c -)
-
 # Unpack Electrum and install it
 RUN tar xfz Electrum-$ELECTRUM_VERSION.tar.gz && ln -s $PWD/Electrum-$ELECTRUM_VERSION/run_electrum /usr/bin/electrum
 RUN electrum version --offline
 
-### Electrum Rust Server ###
-
-# Install Rust 1.41.1
-RUN apt-get install -qq -y clang cmake cargo rustc
-
-# Build electrs and install it
-WORKDIR /build/electrs
-COPY . .
-RUN cargo build --locked --release -p electrs_rpc
-RUN cp target/release/electrs_rpc /usr/bin/electrs
-
-# Install a few test tools and copy the integration tests
+# Copy the binaries
 RUN apt-get install -qqy jq netcat
-
+COPY --from=electrs-build /build/electrs/target/release/electrs_rpc /usr/bin/electrs
+COPY --from=bitcoin-build /build/bitcoin/src/bitcoind /build/bitcoin/src/bitcoin-cli /usr/bin/
+RUN bitcoind -version && bitcoin-cli -version
+WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY . .
 RUN cargo fmt -- --check
 RUN cargo build --locked --release --all
 RUN cargo test --locked --release --all
+RUN cargo install --locked --path electrs_rpc
 
 FROM debian:buster-slim as updated
 RUN apt-get update
@@ -44,7 +45,7 @@ RUN electrum version --offline
 
 # Copy the binaries
 RUN apt-get install -qqy jq netcat
-COPY --from=electrs-build /build/electrs/target/release/electrs_rpc /usr/bin/electrs
+COPY --from=electrs-build /usr/local/cargo/bin/electrs_rpc /usr/bin/electrs
 COPY --from=bitcoin-build /build/bitcoin/src/bitcoind /build/bitcoin/src/bitcoin-cli /usr/bin/
 RUN bitcoind -version && bitcoin-cli -version
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,16 @@
+### Electrum Rust Server ###
+FROM rust:1.41.1-slim as electrs-build
+RUN apt-get update
+RUN apt-get install -qq -y clang cmake
+RUN rustup component add rustfmt
+
+# Build, test and install electrs
+WORKDIR /build/electrs
+COPY . .
+RUN cargo fmt -- --check
+RUN cargo build --locked --release --all
+RUN cargo test --locked --release --all
+
 FROM debian:buster-slim as updated
 RUN apt-get update
 # Install Bitcoin Core runtime dependencies
@@ -18,17 +31,6 @@ RUN git clone --branch locations https://github.com/romanz/bitcoin.git .
 RUN ./autogen.sh
 RUN ./configure --disable-tests --disable-wallet --disable-bench --without-gui --without-miniupnpc
 RUN make -j"$(($(nproc)+1))"
-
-### Electrum Rust Server ###
-FROM updated as electrs-build
-# Install Rust 1.41.1
-RUN apt-get install -qq -y clang cmake cargo rustc
-
-# Build, test and install electrs
-WORKDIR /build/electrs
-COPY . .
-RUN cargo build --locked --release --all
-RUN cargo test --locked --release --all
 
 FROM updated as result
 ### Electrum ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ FROM debian:buster-slim as updated
 RUN apt-get update
 # Install Bitcoin Core runtime dependencies
 RUN apt-get install -qqy libevent-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev
-# Install a few test tools
-RUN apt-get install -qqy jq netcat
 
 ### Bitcoin Core ###
 FROM updated as bitcoin-build
@@ -34,12 +32,12 @@ RUN make -j"$(($(nproc)+1))"
 
 FROM updated as result
 ### Electrum ###
-# Download latest Electrum wallet
-RUN apt-get install -qqy wget libsecp256k1-0 python3-cryptography
-ARG ELECTRUM_VERSION=4.0.5
+# Download latest Electrum wallet and a few test tools
+RUN apt-get install -qqy wget libsecp256k1-0 python3-cryptography jq netcat
+ARG ELECTRUM_VERSION=4.0.6
 WORKDIR /build/electrum
 RUN wget -q https://download.electrum.org/$ELECTRUM_VERSION/Electrum-$ELECTRUM_VERSION.tar.gz \
-&& (echo "6790407e21366186d928c8e653e3ab38476ca86e4797aa4db94dcca2384db41a Electrum-$ELECTRUM_VERSION.tar.gz" | sha256sum -c -)
+&& (echo "4d90047060aaa717184e7c32b538ebf74948b6e00ab6260ab4388f07c4b9e86a Electrum-$ELECTRUM_VERSION.tar.gz" | sha256sum -c -)
 # Unpack Electrum and install it
 RUN tar xfz Electrum-$ELECTRUM_VERSION.tar.gz && ln -s $PWD/Electrum-$ELECTRUM_VERSION/run_electrum /usr/bin/electrum
 RUN electrum version --offline

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
 set -euo pipefail
 
+rm -rf data/
 mkdir -p data/{bitcoin,electrum,electrs}
+
+cleanup() {
+  trap - SIGTERM SIGINT
+  set +eo pipefail
+  kill `jobs -rp`
+  wait `jobs -rp`
+}
+trap cleanup SIGINT SIGTERM EXIT
 
 BTC="bitcoin-cli -regtest -datadir=data/bitcoin"
 ELECTRUM="electrum --regtest"
-EL="$ELECTRUM --wallet data/electrum/wallet"
+EL="$ELECTRUM --wallet=data/electrum/wallet"
+
+tail_log() {
+	tail -n +0 -F data/$1 || true
+}
 
 echo "Starting $(bitcoind -version | head -n1)..."
 bitcoind -regtest -datadir=data/bitcoin -printtoconsole=0 &
@@ -13,7 +26,7 @@ bitcoind -regtest -datadir=data/bitcoin -printtoconsole=0 &
 $BTC -rpcwait getblockcount > /dev/null
 
 echo "Creating Electrum `electrum version --offline` wallet..."
-WALLET=`$EL create --offline --seed_type segwit`
+WALLET=`$EL --offline create --seed_type=segwit`
 MINING_ADDR=`$EL --offline getunusedaddress`
 
 $BTC generatetoaddress 110 $MINING_ADDR > /dev/null
@@ -24,20 +37,24 @@ $BTC getblocklocations $TIP 1000 > /dev/null  # make sure the new RPC works
 
 export RUST_LOG=electrs=debug
 electrs --db-dir=data/electrs --daemon-dir=data/bitcoin --network=regtest 2> data/electrs/regtest-debug.log &
-sleep 1
+tail_log electrs/regtest-debug.log | grep -m1 "serving Electrum RPC"
+tail_log electrs/regtest-debug.log | grep -m1 "verified 111 blocks"  # TODO: wait on subscription
 
-ELECTRS_VERSION=`contrib/health_check.py localhost 60401 | jq -C .[0]`
-TIP_HEADER=`contrib/get_tip.py localhost 60401`
+echo -e '{"jsonrpc": "2.0", "method": "server.version", "params": ["test", "1.4"], "id": 0}\n{"jsonrpc": "2.0", "method": "blockchain.headers.subscribe", "id": 1}' \
+| netcat localhost 60401 > data/electrs/regtest-sub.log &
+
+ELECTRS_VERSION=`tail_log electrs/regtest-sub.log | head -n1 | jq -C '.result[0]'`
+TIP_HEADER=`tail_log electrs/regtest-sub.log | grep -m1 '"height":' | jq .result`
+
 echo "Started ${ELECTRS_VERSION/\// } with `jq -r .height <<< "$TIP_HEADER"` blocks indexed"
 test `jq -r .hex <<< "$TIP_HEADER"` == `$BTC getblockheader $TIP false`
 
 $ELECTRUM daemon --server localhost:60401:t -1 -vDEBUG 2> data/electrum/regtest-debug.log &
-sleep 1
-$EL getinfo | jq -C -c .
+tail_log electrum/regtest-debug.log | grep -m1 "connection established"
+$EL getinfo
 
 echo "Loading Electrum wallet..."
 test `$EL load_wallet` == "true"
-sleep 1
 
 echo "Running integration tests:"
 
@@ -62,6 +79,7 @@ test "`$EL getbalance | jq -c .`" == '{"confirmed":"550","unconfirmed":"-0.001",
 echo "Generating bitcoin block..."
 $BTC generatetoaddress 1 $MINING_ADDR > /dev/null
 $BTC getblockcount > /dev/null
+tail_log electrum/regtest-debug.log | grep -m1 "verified $TXID"
 
 echo " * get_tx_status"
 test "`$EL get_tx_status $TXID | jq -c .`" == '{"confirmations":1}'
@@ -71,3 +89,8 @@ test "`$EL getaddresshistory $NEW_ADDR | jq -c .`" == "[{\"fee\":null,\"height\"
 
 echo " * getbalance"
 test "`$EL getbalance | jq -c .`" == '{"confirmed":"599.999","unmatured":"4950.001"}'
+
+$BTC stop  # should also stop electrs
+echo "Electrum `$EL stop`"
+
+echo "=== PASSED ==="

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -26,14 +26,14 @@ export RUST_LOG=electrs=debug
 electrs --db-dir=data/electrs --daemon-dir=data/bitcoin --network=regtest 2> data/electrs/regtest-debug.log &
 sleep 1
 
-ELECTRS_VERSION=`contrib/health_check.py localhost 60401 | jq -r .[0]`
+ELECTRS_VERSION=`contrib/health_check.py localhost 60401 | jq -C .[0]`
 TIP_HEADER=`contrib/get_tip.py localhost 60401`
 echo "Started ${ELECTRS_VERSION/\// } with `jq -r .height <<< "$TIP_HEADER"` blocks indexed"
 test `jq -r .hex <<< "$TIP_HEADER"` == `$BTC getblockheader $TIP false`
 
 $ELECTRUM daemon --server localhost:60401:t -1 -vDEBUG 2> data/electrum/regtest-debug.log &
 sleep 1
-$EL getinfo | jq -c .
+$EL getinfo | jq -C -c .
 
 echo "Loading Electrum wallet..."
 test `$EL load_wallet` == "true"


### PR DESCRIPTION
https://github.com/romanz/electrs/runs/1492953787:
```
Run docker run -v $PWD/contrib/:/contrib -v $PWD/tests/:/tests --rm electrs:tests bash /tests/run.sh
Starting Bitcoin Core version v21.99.0-4165780c7...
Creating Electrum 4.0.5 wallet...
Generated 110 regtest blocks (33.167 kB) to bcrt1qgaddyzpdljaa7ry7cjh4en740c03ewgkjwgfh2
Started "electrs 0.9.0" with 110 blocks indexed
{"auto_connect":false,"blockchain_height":110,"connected":true,"default_wallet":"/root/.electrum/regtest/wallets/default_wallet","fee_per_kb":180000,"path":"/root/.electrum/regtest","server":"localhost","server_height":110,"spv_nodes":1,"version":"4.0.5"}
Loading Electrum wallet...
Running integration tests:
 * getbalance
 * getunusedaddress
 * payto & broadcast
 * get_tx_status
 * getaddresshistory
 * getbalance
Generating bitcoin block...
 * get_tx_status
 * getaddresshistory
 * getbalance
```