### PR TITLE
Use sync primitives from parking_lot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,7 @@ dependencies = [
  "lru",
  "num_cpus",
  "page_size",
+ "parking_lot",
  "prometheus",
  "protobuf",
  "rocksdb",
@@ -435,6 +436,12 @@ checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fmt2io"
@@ -545,6 +552,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -763,12 +780,15 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
+ "backtrace",
  "cfg-if 0.1.10",
  "cloudabi",
  "instant",
  "libc",
+ "petgraph",
  "redox_syscall",
  "smallvec",
+ "thread-id",
  "winapi 0.3.9",
 ]
 
@@ -789,6 +809,16 @@ name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1121,6 +1151,17 @@ dependencies = [
  "proc-macro2 1.0.23",
  "quote 1.0.7",
  "syn",
+]
+
+[[package]]
+name = "thread-id"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ lto = true
 
 [features]
 default = ["rocksdb/snappy", "rocksdb/lz4", "rocksdb/zstd", "rocksdb/zlib", "rocksdb/bzip2"]
+detect_deadlocks = ["parking_lot/deadlock_detection"]
 
 [dependencies]
 base64 = "0.10"
@@ -49,6 +50,7 @@ stderrlog = "0.4.1"
 sysconf = ">=0.3.4"
 time = "0.1"
 tiny_http = "0.6"
+parking_lot = "0.11.1"
 
 [build-dependencies]
 configure_me_codegen = "0.3.12"

--- a/examples/index.rs
+++ b/examples/index.rs
@@ -5,12 +5,12 @@ extern crate error_chain;
 #[macro_use]
 extern crate log;
 
+use electrs::sync::Arc;
 use electrs::{
     cache::BlockTxIDsCache, config::Config, daemon::Daemon, errors::*, fake::FakeStore,
     index::Index, metrics::Metrics, signal::Waiter,
 };
 use error_chain::ChainedError;
-use std::sync::Arc;
 
 fn run() -> Result<()> {
     let signal = Waiter::start();

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
+use crate::sync::{Arc, Mutex};
 use bitcoin::hash_types::BlockHash;
-use std::sync::{Arc, Mutex};
 
 use crate::{config::Config, daemon, errors::*, index, signal::Waiter, store};
 

--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -4,9 +4,9 @@ extern crate error_chain;
 #[macro_use]
 extern crate log;
 
+use electrs::sync::Arc;
 use error_chain::ChainedError;
 use std::process;
-use std::sync::Arc;
 
 use electrs::{
     app::App,

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -1,3 +1,7 @@
+use crate::sync::{
+    mpsc::{Receiver, SyncSender},
+    Arc, Mutex,
+};
 use bitcoin::blockdata::block::Block;
 use bitcoin::consensus::encode::{deserialize, Decodable};
 use bitcoin::hash_types::BlockHash;
@@ -5,10 +9,6 @@ use std::collections::HashSet;
 use std::fs;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
-use std::sync::{
-    mpsc::{Receiver, SyncSender},
-    Arc, Mutex,
-};
 use std::thread;
 
 use crate::daemon::Daemon;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,13 +1,13 @@
 use crate::errors::*;
 use crate::metrics::{CounterVec, MetricOpts, Metrics};
 
+use crate::sync::Mutex;
 use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::hash_types::{BlockHash, Txid};
 use lru::LruCache;
 use prometheus::IntGauge;
 use std::hash::Hash;
-use std::sync::Mutex;
 
 struct SizedLruCache<K, V> {
     map: LruCache<K, (V, usize)>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::sync::Arc;
 use bitcoin::network::constants::Network;
 use dirs_next::home_dir;
 use std::convert::TryInto;
@@ -8,7 +9,6 @@ use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Duration;
 
 use crate::daemon::CookieGetter;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,3 +1,5 @@
+use crate::sync::atomic::{AtomicU64, Ordering};
+use crate::sync::{Arc, Mutex};
 use bitcoin::blockdata::block::{Block, BlockHeader};
 use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::consensus::encode::{deserialize, serialize};
@@ -10,8 +12,6 @@ use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Lines, Write};
 use std::net::{SocketAddr, TcpStream};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crate::cache::BlockTxIDsCache;

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,3 +1,4 @@
+use crate::sync::RwLock;
 use bitcoin::blockdata::block::{Block, BlockHeader};
 use bitcoin::blockdata::transaction::{Transaction, TxIn, TxOut};
 use bitcoin::consensus::encode::{deserialize, serialize};
@@ -5,7 +6,6 @@ use bitcoin::hash_types::{BlockHash, Txid};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
-use std::sync::RwLock;
 
 use crate::daemon::Daemon;
 use crate::errors::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,4 +25,5 @@ pub mod query;
 pub mod rpc;
 pub mod signal;
 pub mod store;
+pub mod sync;
 pub mod util;

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -1,9 +1,9 @@
+use crate::sync::Mutex;
 use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::hash_types::Txid;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter::FromIterator;
 use std::ops::Bound;
-use std::sync::Mutex;
 
 use crate::daemon::{Daemon, MempoolEntry};
 use crate::errors::*;

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -7,7 +7,7 @@ use bitcoin::network::socket::Socket;
 use bitcoin::hash_types::Txid;
 use bitcoin::util::Error;
 
-use std::sync::mpsc::Sender;
+use crate::sync::mpsc::Sender;
 use std::thread;
 use std::time::Duration;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,3 +1,4 @@
+use crate::sync::{Arc, RwLock};
 use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::hash_types::{BlockHash, TxMerkleNode, Txid};
@@ -7,7 +8,6 @@ use bitcoin::hashes::Hash;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
 
 use crate::app::App;
 use crate::cache::TransactionCache;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,3 +1,5 @@
+use crate::sync::mpsc::{self, Receiver, Sender, SyncSender, TrySendError};
+use crate::sync::{Arc, Mutex};
 use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::consensus::encode::{deserialize, serialize};
 use bitcoin::hashes::hex::{FromHex, ToHex};
@@ -7,8 +9,6 @@ use serde_json::{from_str, Value};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
-use std::sync::mpsc::{self, Receiver, Sender, SyncSender, TrySendError};
-use std::sync::{Arc, Mutex};
 use std::thread;
 
 use crate::errors::*;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,178 @@
+// We put these things in submodule in case we need to change the impls easily
+pub use self::parking_lot::*;
+
+mod parking_lot {
+    use std::sync::{LockResult, PoisonError, TryLockError, TryLockResult};
+
+    // We just reexport std type as parking_lot doesn't have any improved version of these
+    pub use std::sync::atomic;
+    pub use std::sync::Arc;
+    // TODO: maybe use crossbeam_channel?
+    pub use std::sync::mpsc;
+
+    // renaming allows us to switch impl if needed
+    use parking_lot::Mutex as MutexImpl;
+    use parking_lot::MutexGuard as MutexGuardImpl;
+
+    struct MutexData<T> {
+        poisoned: bool,
+        value: T,
+    }
+
+    /// Mutex from parking_lot with poisoning added on top
+    pub struct Mutex<T>(MutexImpl<MutexData<T>>);
+
+    impl<T> Mutex<T> {
+        pub fn new(value: T) -> Self {
+            Mutex(MutexImpl::new(MutexData {
+                poisoned: false,
+                value,
+            }))
+        }
+    }
+
+    impl<T> Mutex<T> {
+        pub fn lock(&self) -> LockResult<MutexGuard<'_, T>> {
+            let guard = self.0.lock();
+            if guard.poisoned {
+                Err(PoisonError::new(MutexGuard(guard)))
+            } else {
+                Ok(MutexGuard(guard))
+            }
+        }
+
+        pub fn try_lock(&self) -> TryLockResult<MutexGuard<'_, T>> {
+            let guard = self.0.try_lock();
+            match guard {
+                Some(guard) if guard.poisoned => {
+                    Err(TryLockError::Poisoned(PoisonError::new(MutexGuard(guard))))
+                }
+                Some(guard) => Ok(MutexGuard(guard)),
+                None => Err(TryLockError::WouldBlock),
+            }
+        }
+    }
+
+    pub struct MutexGuard<'a, T>(MutexGuardImpl<'a, MutexData<T>>);
+
+    impl<'a, T> std::ops::Deref for MutexGuard<'a, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0.value
+        }
+    }
+
+    impl<'a, T> std::ops::DerefMut for MutexGuard<'a, T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut (*self.0).value
+        }
+    }
+
+    impl<'a, T> Drop for MutexGuard<'a, T> {
+        fn drop(&mut self) {
+            if std::thread::panicking() {
+                (*self.0).poisoned = true;
+            }
+        }
+    }
+
+    use parking_lot::RwLock as RwLockImpl;
+    use parking_lot::RwLockReadGuard as RwLockReadGuardImpl;
+    use parking_lot::RwLockWriteGuard as RwLockWriteGuardImpl;
+
+    struct RwLockData<T> {
+        poisoned: bool,
+        value: T,
+    }
+
+    /// RwLock from parking_lot with poisoning added on top
+    pub struct RwLock<T>(RwLockImpl<RwLockData<T>>);
+
+    impl<T> RwLock<T> {
+        pub fn new(value: T) -> Self {
+            RwLock(RwLockImpl::new(RwLockData {
+                poisoned: false,
+                value,
+            }))
+        }
+    }
+
+    impl<T> RwLock<T> {
+        pub fn read(&self) -> LockResult<RwLockReadGuard<'_, T>> {
+            let guard = self.0.read();
+            if guard.poisoned {
+                Err(PoisonError::new(RwLockReadGuard(guard)))
+            } else {
+                Ok(RwLockReadGuard(guard))
+            }
+        }
+
+        pub fn write(&self) -> LockResult<RwLockWriteGuard<'_, T>> {
+            let guard = self.0.write();
+            if guard.poisoned {
+                Err(PoisonError::new(RwLockWriteGuard(guard)))
+            } else {
+                Ok(RwLockWriteGuard(guard))
+            }
+        }
+
+        pub fn try_read(&self) -> TryLockResult<RwLockReadGuard<'_, T>> {
+            let guard = self.0.try_read();
+            match guard {
+                Some(guard) if guard.poisoned => Err(TryLockError::Poisoned(PoisonError::new(
+                    RwLockReadGuard(guard),
+                ))),
+                Some(guard) => Ok(RwLockReadGuard(guard)),
+                None => Err(TryLockError::WouldBlock),
+            }
+        }
+
+        pub fn try_write(&self) -> TryLockResult<RwLockWriteGuard<'_, T>> {
+            let guard = self.0.try_write();
+            match guard {
+                Some(guard) if guard.poisoned => Err(TryLockError::Poisoned(PoisonError::new(
+                    RwLockWriteGuard(guard),
+                ))),
+                Some(guard) => Ok(RwLockWriteGuard(guard)),
+                None => Err(TryLockError::WouldBlock),
+            }
+        }
+    }
+
+    pub struct RwLockReadGuard<'a, T>(RwLockReadGuardImpl<'a, RwLockData<T>>);
+
+    impl<'a, T> std::ops::Deref for RwLockReadGuard<'a, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0.value
+        }
+    }
+
+    // No Drop for RwLockReadGuard because readers can't change data/violate invariants
+
+    pub struct RwLockWriteGuard<'a, T>(RwLockWriteGuardImpl<'a, RwLockData<T>>);
+
+    impl<'a, T> std::ops::Deref for RwLockWriteGuard<'a, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0.value
+        }
+    }
+
+    impl<'a, T> std::ops::DerefMut for RwLockWriteGuard<'a, T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut (*self.0).value
+        }
+    }
+
+    impl<'a, T> Drop for RwLockWriteGuard<'a, T> {
+        fn drop(&mut self) {
+            if std::thread::panicking() {
+                (*self.0).poisoned = true;
+            }
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use crate::sync::mpsc::{channel, sync_channel, Receiver, Sender, SyncSender};
 use bitcoin::blockdata::block::BlockHeader;
 use bitcoin::hash_types::BlockHash;
 use std::collections::HashMap;
@@ -5,7 +6,6 @@ use std::convert::TryInto;
 use std::fmt;
 use std::iter::FromIterator;
 use std::slice;
-use std::sync::mpsc::{channel, sync_channel, Receiver, Sender, SyncSender};
 use std::thread;
 
 pub type Bytes = Vec<u8>;


### PR DESCRIPTION
This change adds a custom module mimicking `std::sync` which may contain
custom implementations of synchronization primitives. It also redirects
all cases of `std::sync` to use this new module and replaces mutexes
with thosse from `parking_lot`.

The main motivation is to help with finding deadlocks using deadlock
detection feature from `parking_lot`. The locks from `parking_lot` don't
implement poisoning so we needed to add it on top to maintain perfect
compatibility. This was solved by wrapping locks in custom types which
mirror the `std` API.

Deadlock detection is behind a feature flag to not slow donw production
use and also because it's considered experimental.

Because this change makes swapping primitives easy, we could try
replacing more of them in the future and measure performance impact.
However I don't expect significant changes and we should focus on
low-hanging fruit first.