### PR TITLE
Reduce the default `index_batch_size` to 10

### DIFF
--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -92,7 +92,7 @@ default = "5"
 name = "index_batch_size"
 type = "usize"
 doc = "Number of blocks to get in one JSONRPC request from bitcoind"
-default = "100"
+default = "10"
 
 [[param]]
 name = "bulk_index_threads"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -541,21 +541,6 @@ impl Daemon {
         Ok(self.request("getrawtransaction", args)?)
     }
 
-    pub fn gettransactions(&self, txhashes: &[&Txid]) -> Result<Vec<Transaction>> {
-        let params_list: Vec<Value> = txhashes
-            .iter()
-            .map(|txhash| json!([txhash.to_hex(), /*verbose=*/ false]))
-            .collect();
-
-        let values = self.requests("getrawtransaction", &params_list)?;
-        let mut txs = vec![];
-        for value in values {
-            txs.push(tx_from_value(value)?);
-        }
-        assert_eq!(txhashes.len(), txs.len());
-        Ok(txs)
-    }
-
     pub fn getmempooltxids(&self) -> Result<HashSet<Txid>> {
         let txids: Value = self.request("getrawmempool", json!([/*verbose=*/ false]))?;
         let mut result = HashSet::new();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -516,19 +516,6 @@ impl Daemon {
             .get_or_else(&blockhash, || self.load_blocktxids(blockhash))
     }
 
-    pub fn getblocks(&self, blockhashes: &[BlockHash]) -> Result<Vec<Block>> {
-        let params_list: Vec<Value> = blockhashes
-            .iter()
-            .map(|hash| json!([hash.to_hex(), /*verbose=*/ false]))
-            .collect();
-        let values = self.requests("getblock", &params_list)?;
-        let mut blocks = vec![];
-        for value in values {
-            blocks.push(block_from_value(value)?);
-        }
-        Ok(blocks)
-    }
-
     pub fn gettransaction(
         &self,
         txhash: &Txid,

--- a/src/index.rs
+++ b/src/index.rs
@@ -384,9 +384,13 @@ impl Index {
         let blockhashes: Vec<BlockHash> = new_headers.iter().map(|h| *h.hash()).collect();
         let batch_size = self.batch_size;
         let fetcher = spawn_thread("fetcher", move || {
-            for chunk in blockhashes.chunks(batch_size) {
+            for blockhashes_chunk in blockhashes.chunks(batch_size) {
+                let blocks = blockhashes_chunk
+                    .iter()
+                    .map(|blockhash| daemon.getblock(blockhash))
+                    .collect();
                 sender
-                    .send(daemon.getblocks(&chunk))
+                    .send(blocks)
                     .expect("failed sending blocks to be indexed");
             }
             sender

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -215,11 +215,14 @@ impl Tracker {
             })
             .collect();
         if !entries.is_empty() {
-            let txids: Vec<&Txid> = entries.iter().map(|(txid, _)| *txid).collect();
-            let txs = match daemon.gettransactions(&txids) {
+            let txs = match entries
+                .iter()
+                .map(|(txid, _)| daemon.gettransaction(txid, None))
+                .collect::<Result<Vec<_>>>()
+            {
                 Ok(txs) => txs,
                 Err(err) => {
-                    debug!("failed to get transactions {:?}: {}", txids, err); // e.g. new block or RBF
+                    debug!("failed to get {} transactions: {}", entries.len(), err); // e.g. new block or RBF
                     return Ok(()); // keep the mempool until next update()
                 }
             };


### PR DESCRIPTION
Also use non-batched RPCs, to lower bitcoind RAM usage.

Following https://github.com/romanz/electrs/issues/373.