### PR TITLE
Fixed inverted logic of deprecation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -173,7 +173,7 @@ fn create_cookie_getter(
 
 /// Processes deprecation of cookie in favor of auth
 fn select_auth(auth: Option<String>, cookie: Option<String>) -> Option<String> {
-    match (auth, cookie) {
+    match (cookie, auth) {
         (None, None) => None,
         (Some(value), None) => {
             eprintln!("WARNING: cookie option is deprecated and will be removed in the future!");


### PR DESCRIPTION
The warning was supposed to be shown when `cookie` is specified not the
other way around.

I have no clue how this slipped through, sorry. :(