### PR TITLE
Ignore individual mempool transaction fetch fails

### DIFF
--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -203,8 +203,7 @@ impl Tracker {
 
         let timer = self.stats.start_timer("add");
         let txids_iter = new_txids.difference(&old_txids);
-        let entries: Vec<(&Txid, MempoolEntry)> = txids_iter
-            .filter_map(|txid| {
+        let entries = txids_iter.filter_map(|txid| {
                 match daemon.getmempoolentry(txid) {
                     Ok(entry) => Some((txid, entry)),
                     Err(err) => {
@@ -212,23 +211,16 @@ impl Tracker {
                         None // ignore this transaction for now
                     }
                 }
-            })
-            .collect();
-        if !entries.is_empty() {
-            let txs = match entries
-                .iter()
-                .map(|(txid, _)| daemon.gettransaction(txid, None))
-                .collect::<Result<Vec<_>>>()
-            {
-                Ok(txs) => txs,
+            });
+        for (txid, entry) in entries {
+            match daemon.gettransaction(txid, None) {
+                Ok(tx) => {
+                    assert_eq!(tx.txid(), *txid);
+                    self.add(txid, tx, entry);
+                },
                 Err(err) => {
-                    debug!("failed to get {} transactions: {}", entries.len(), err); // e.g. new block or RBF
-                    return Ok(()); // keep the mempool until next update()
+                    debug!("failed to get transaction {}: {}", txid, err); // e.g. new block or RBF
                 }
-            };
-            for ((txid, entry), tx) in entries.into_iter().zip(txs.into_iter()) {
-                assert_eq!(tx.txid(), *txid);
-                self.add(txid, tx, entry);
             }
         }
         timer.observe_duration();

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -204,20 +204,20 @@ impl Tracker {
         let timer = self.stats.start_timer("add");
         let txids_iter = new_txids.difference(&old_txids);
         let entries = txids_iter.filter_map(|txid| {
-                match daemon.getmempoolentry(txid) {
-                    Ok(entry) => Some((txid, entry)),
-                    Err(err) => {
-                        debug!("no mempool entry {}: {}", txid, err); // e.g. new block or RBF
-                        None // ignore this transaction for now
-                    }
+            match daemon.getmempoolentry(txid) {
+                Ok(entry) => Some((txid, entry)),
+                Err(err) => {
+                    debug!("no mempool entry {}: {}", txid, err); // e.g. new block or RBF
+                    None // ignore this transaction for now
                 }
-            });
+            }
+        });
         for (txid, entry) in entries {
             match daemon.gettransaction(txid, None) {
                 Ok(tx) => {
                     assert_eq!(tx.txid(), *txid);
                     self.add(txid, tx, entry);
-                },
+                }
                 Err(err) => {
                     debug!("failed to get transaction {}: {}", txid, err); // e.g. new block or RBF
                 }


### PR DESCRIPTION
I wrote this in the github editor, so no promises that it compiles, but this should avoid several extra heap allocations and moves while fetching the mempool, and, more importantly, get electrs out of an infinite loop of fetching the full mempool forever when there exist RBF transactions.