### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,29 @@
-FROM rust:1.44.1-slim-buster
+FROM rust:1.44.1-slim-buster as builder
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends clang=1:7.* cmake=3.* \
-     libsnappy-dev=1.* curl \
+  libsnappy-dev=1.* curl \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 RUN adduser --disabled-login --system --shell /bin/false --uid 1000 user
 
 WORKDIR /home/user
-COPY ./ /home/user
+COPY . .
 RUN chown -R user .
 
-USER user
-
 RUN cargo install --locked --path .
+
+# Create runtime image
+FROM debian:buster-slim
+
+RUN adduser --disabled-login --system --shell /bin/false --uid 1000 user
+
+WORKDIR /home/user/app
+RUN chown user .
+COPY --from=builder /home/user/target/release .
+
+USER user
 
 # Electrum RPC
 EXPOSE 50001
@@ -25,3 +34,5 @@ EXPOSE 4224
 STOPSIGNAL SIGINT
 
 HEALTHCHECK CMD curl -fSs http://localhost:4224/ || exit 1
+
+ENTRYPOINT ["./electrs", "-vvvv", "--timestamp"]

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -137,7 +137,7 @@ $ mkdir db
 $ docker run --network host \
              --volume $HOME/.bitcoin:/home/user/.bitcoin:ro \
              --volume $PWD/db:/home/user/db \
-             --env ELECTRS_DB_DIR=/home/user/db
+             --env ELECTRS_DB_DIR=/home/user/db \
              --rm -i -t electrs-app
 ```
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -133,11 +133,12 @@ Note: currently Docker installation links statically
 
 ```bash
 $ docker build -t electrs-app .
+$ mkdir db
 $ docker run --network host \
              --volume $HOME/.bitcoin:/home/user/.bitcoin:ro \
-             --volume $PWD:/home/user \
-             --rm -i -t electrs-app \
-             electrs -vvvv --timestamp --db-dir /home/user/db
+             --volume $PWD/db:/home/user/db \
+             --env ELECTRS_DB_DIR=/home/user/db
+             --rm -i -t electrs-app
 ```
 
 ## Native OS packages


### PR DESCRIPTION
This adds an Entrypoint to the Dockerfile and fixes #322.

It also introduces multistage Docker build, that reduces the image size from ~1.85GB to ~463MB, because the rust toolchain is no longer in the resulting image.