### PR TITLE
Fix Dockerfile, add another example

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -131,15 +131,34 @@ If you installed `cfg_me` to generate man page, you can run `cfg_me man` to see 
 
 Note: currently Docker installation links statically
 
+Note: health check only works if Prometheus is running on port 4224 inside container
+
 ```bash
 $ docker build -t electrs-app .
 $ mkdir db
 $ docker run --network host \
              --volume $HOME/.bitcoin:/home/user/.bitcoin:ro \
              --volume $PWD/db:/home/user/db \
+             --env ELECTRS_VERBOSE=4 \
+             --env ELECTRS_TIMESTAMP=true \
              --env ELECTRS_DB_DIR=/home/user/db \
              --rm -i -t electrs-app
 ```
+
+If not using the host-network, you probably want to expose the ports for electrs and Prometheus like so:
+
+```bash
+$ docker run --volume $HOME/.bitcoin:/home/user/.bitcoin:ro \
+             --volume $PWD/db:/home/user/db \
+             --env ELECTRS_VERBOSE=4 \
+             --env ELECTRS_TIMESTAMP=true \
+             --env ELECTRS_DB_DIR=/home/user/db \
+             --env ELECTRS_ELECTRUM_RPC_ADDR=0.0.0.0:50001 \
+             --env ELECTRS_MONITORING_ADDR=0.0.0.0:4224 \
+             --rm -i -t electrs-app
+```
+
+To access the server from outside Docker, add `-p 50001:50001 -p 4224:4224` but be aware of the security risks. Good practice is to group containers that needs access to the server inside the same Docker network and not expose the ports to the outside world.
 
 ## Native OS packages
 


### PR DESCRIPTION
With my last PR #387 I messed up with filesystem permissions and health check. This is going to fix that. Besides this I removed the parameters from entrypoint, so they can be set via env variables. Also removed obsolete lines from Dockerfile and added another example for running the image.