### PR TITLE
Make sysconf dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0"
 sha2 = "0.9.2"
 signal-hook = "0.1"
 stderrlog = "0.5.1"
-sysconf = ">=0.3.4"
+sysconf = {version = ">=0.3.4", optional=true}
 time = "0.1"
 tiny_http = "0.6"
 


### PR DESCRIPTION
Allow building without sysconf dependency. Re. https://github.com/romanz/electrs/issues/294


