### PR TITLE
Use more detailed error codes

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,16 @@
+use serde_json::Value;
+
 error_chain! {
     types {
         Error, ErrorKind, ResultExt, Result;
     }
 
     errors {
+        Daemon(method: String, err: Value) {
+            description("RPC error")
+            display("{} RPC error: {}", method, err)
+        }
+
         Connection(msg: String) {
             description("Connection error")
             display("Connection error: {}", msg)
@@ -12,6 +19,21 @@ error_chain! {
         Interrupt(sig: i32) {
             description("Interruption by external signal")
             display("Interrupted by signal {}", sig)
+        }
+
+        MethodNotFound(method: String) {
+            description("method not found")
+            display("method not found '{}'", method)
+        }
+
+        InvalidRequest(message: &'static str) {
+            description("invalid request")
+            display("invalid request: {}", message)
+        }
+
+        ParseError {
+            description("parse error")
+            display("parse error")
         }
     }
 }


### PR DESCRIPTION
Reply to malformed json-rpc requests with json-rpc responses containing a spec-compliant error code. For electrum-protocol-specific errors reply with an error code of 1 (`BAD_REQUEST`) or 2 (`DAEMON_ERROR`) depending on whether the error originated from the daemon or not.

**Edit:** This builds on the changes in #390, which was a fix for #313