### PR TITLE
Updated tiny_http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "tiny_http"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1661fa0a44c95d01604bd05c66732a446c657efb62b5164a7a083a3b552b4951"
+checksum = "2e22cb179b63e5fc2d0b5be237dc107da072e2407809ac70a8ce85b93fe8f562"
 dependencies = [
  "ascii",
  "chrono",


### PR DESCRIPTION
The previous version of `tiny_http` had a vulnerability that's probably
not relevant to `electrs` but better not risk it. It also avoids ugly
red error from `cargo audit`. :)