### PR TITLE
Disable 'clippy::identity_conversion' on generated configuration module + add clippy to CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,13 @@
 FROM rust:1.41.1-slim as electrs-build
 RUN apt-get update
 RUN apt-get install -qq -y clang cmake
-RUN rustup component add rustfmt
+RUN rustup component add rustfmt clippy
 
 # Build, test and install electrs
 WORKDIR /build/electrs
 COPY . .
 RUN cargo fmt -- --check
+RUN cargo clippy
 RUN cargo build --locked --release --all
 RUN cargo test --locked --release --all
 RUN cargo install --locked --path .

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ const DEFAULT_SERVER_ADDRESS: [u8; 4] = [127, 0, 0, 1]; // by default, serve on 
 
 mod internal {
     #![allow(unused)]
+    #![allow(clippy::identity_conversion)]
 
     include!(concat!(env!("OUT_DIR"), "/configure_me_config.rs"));
 }


### PR DESCRIPTION
Otherwise, clippy fails with:

```
warning: identical conversion
   --> /media/roman/3TB/roman/Code/electrs/target/debug/build/electrs-56b1e395b2bcf88c/out/configure_me_config.rs:339:25
    |
339 |                 db_dir: db_dir.into(),
    |                         ^^^^^^^^^^^^^ help: consider removing `.into()`: `db_dir`
    |
    = note: `#[warn(clippy::identity_conversion)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion

warning: identical conversion
   --> /media/roman/3TB/roman/Code/electrs/target/debug/build/electrs-56b1e395b2bcf88c/out/configure_me_config.rs:340:29
    |
340 |                 daemon_dir: daemon_dir.into(),
    |                             ^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `daemon_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion

warning: identical conversion
   --> /media/roman/3TB/roman/Code/electrs/target/debug/build/electrs-56b1e395b2bcf88c/out/configure_me_config.rs:349:37
    |
349 |                 wait_duration_secs: wait_duration_secs.into(),
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `wait_duration_secs`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion

warning: identical conversion
   --> /media/roman/3TB/roman/Code/electrs/target/debug/build/electrs-56b1e395b2bcf88c/out/configure_me_config.rs:350:35
    |
350 |                 index_batch_size: index_batch_size.into(),
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `index_batch_size`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion

warning: identical conversion
   --> /media/roman/3TB/roman/Code/electrs/target/debug/build/electrs-56b1e395b2bcf88c/out/configure_me_config.rs:351:29
    |
351 |                 txid_limit: txid_limit.into(),
    |                             ^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `txid_limit`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion

warning: identical conversion
   --> /media/roman/3TB/roman/Code/electrs/target/debug/build/electrs-56b1e395b2bcf88c/out/configure_me_config.rs:352:32
    |
352 |                 server_banner: server_banner.into(),
    |                                ^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `server_banner`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion
    ```