### PR TITLE
Force MSRV in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache: cargo
 before_script:
   - rustup component add rustfmt-preview
   - rustup component add clippy
+  - rustup default 1.41.1
 
 script:
   - cargo fmt --all -- --check

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_script:
   - rustup default 1.41.1
 
 script:
-  - cargo fmt --all -- --check
-  - cargo check --all
-  - cargo clippy --all
-  - cargo build --all
-  - cargo test --all
+  - cargo +1.41.1 fmt --all -- --check
+  - cargo +1.41.1 check --all
+  - cargo +1.41.1 clippy --all
+  - cargo +1.41.1 build --all
+  - cargo +1.41.1 test --all


### PR DESCRIPTION
This should hopefully prevent CI from using wrong Rust version.
Strictly speaking, rustup should use the version from `rust-toolchain` file but it looks like it was ignored.