### PR TITLE
Set toolchain in GitHub actions to 1.41.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.41.1
           components: rustfmt
           profile: minimal
           override: true


### PR DESCRIPTION
This should make sure to catch compatibility mistakes in commits.

I used some nicer trick in the past but at first I'd like to see if this helps at all.