### PR TITLE
Use the same log verbosity levels as master

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -268,11 +268,11 @@ impl Config {
         });
 
         let level = match config.verbose {
-            0 => LevelFilter::Error,
-            1 => LevelFilter::Warn,
-            2 => LevelFilter::Info,
-            3 => LevelFilter::Debug,
-            _ => LevelFilter::Trace,
+            0 => log::LevelFilter::Error,
+            1 => log::LevelFilter::Warn,
+            2 => log::LevelFilter::Info,
+            3 => log::LevelFilter::Debug,
+            _ => log::LevelFilter::Trace,
         };
 
         let config = Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -268,9 +268,11 @@ impl Config {
         });
 
         let level = match config.verbose {
-            0 => log::LevelFilter::Info,
-            1 => log::LevelFilter::Debug,
-            _ => log::LevelFilter::Trace,
+            0 => LevelFilter::Error,
+            1 => LevelFilter::Warn,
+            2 => LevelFilter::Info,
+            3 => LevelFilter::Debug,
+            _ => LevelFilter::Trace,
         };
 
         let config = Config {


### PR DESCRIPTION
Current verbosity level of master are the ones here: https://docs.rs/stderrlog/0.5.1/src/stderrlog/lib.rs.html#377

p2p branch uses different level values for verbosity d153bfa2eb4435fbe2f70d38ece76152c0bcff66. This surprised me when testing outpoint notification in p2p branch (the trace logs fill my disk storage completely after two days of usage).

This PR restores the same old levels in p2p branch as master.