### PR TITLE
Add snappy to RocksDB features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,9 @@ rev = "06ac9fa3e834413f7afeaed322cf8098d876e4a0"
 git = "https://github.com/romanz/rust-rocksdb"
 rev = "2023b18a7b83fc47b5bc950b5322a2284b771162"
 default-features = false
-features = ["zstd"]
+# ZSTD is used for data compression
+# Snappy is only for checking old DB
+features = ["zstd", "snappy"]
 
 [build-dependencies]
 configure_me_codegen = "0.4"


### PR DESCRIPTION
It would be useful to detect old DBs:
https://github.com/romanz/electrs/pull/477#discussion_r707600255

RocksDB compilation time increases 1m03s -> 1m07s (+6%).
Total electrs build time is 2m05s.