### PR TITLE
Simplify 'blockchain.scripthash.get_balance' implementation 

### DIFF
--- a/contrib/history.py
+++ b/contrib/history.py
@@ -67,12 +67,11 @@ def main():
         client.request('blockchain.scripthash.get_balance', script_hash)
         for script_hash in script_hashes
     )
-    balances = [balance["confirmed"] for balance in balances]
-    total = sum(balances)
     for balance, addr in sorted(zip(balances, args.address)):
-        if balance:
-            log.debug('{:15,.5f} mBTC at {}', balance / 1e5, addr)
-    log.debug('{:15,.5f} mBTC (total)', total / 1e5)
+        if balance["confirmed"]:
+            log.info("{}: confirmed {:,.5f} mBTC", addr, balance["confirmed"] / 1e5)
+        if balance["unconfirmed"]:
+            log.info("{}: unconfirmed {:,.5f} mBTC", addr, balance["unconfirmed"] / 1e5)
 
     histories = conn.call(
         client.request('blockchain.scripthash.get_history', script_hash)

--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -226,19 +226,16 @@ impl Rpc {
         (scripthash,): (ScriptHash,),
     ) -> Result<Value> {
         let balance = match client.scripthashes.get(&scripthash) {
-            Some(status) => self.tracker.get_balance(status, &self.cache),
+            Some(status) => self.tracker.get_balance(&status),
             None => {
                 warn!(
                     "blockchain.scripthash.get_balance called for unsubscribed scripthash: {}",
                     scripthash
                 );
-                self.tracker
-                    .get_balance(&self.new_status(scripthash)?, &self.cache)
+                self.tracker.get_balance(&self.new_status(scripthash)?)
             }
         };
-        Ok(
-            json!({"confirmed": balance.confirmed.as_sat(), "unconfirmed": balance.mempool_delta.as_sat()}),
-        )
+        Ok(json!(balance))
     }
 
     fn scripthash_get_history(

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result};
-use bitcoin::{BlockHash, OutPoint, Txid};
+use bitcoin::{BlockHash, Txid};
 
-use std::convert::TryFrom;
 use std::path::Path;
 
 use crate::{
@@ -76,17 +75,8 @@ impl Tracker {
         Ok(prev_statushash != status.statushash())
     }
 
-    pub(crate) fn get_balance(&self, status: &ScriptHashStatus, cache: &Cache) -> Balance {
-        let get_amount_fn = |outpoint: OutPoint| {
-            cache
-                .get_tx(&outpoint.txid, |tx| {
-                    let vout = usize::try_from(outpoint.vout).unwrap();
-                    bitcoin::Amount::from_sat(tx.output[vout].value)
-                })
-                .expect("missing tx")
-        };
-
-        status.get_balance(self.chain(), get_amount_fn)
+    pub(crate) fn get_balance(&self, status: &ScriptHashStatus) -> Balance {
+        status.get_balance(self.chain())
     }
 
     pub fn get_blockhash_by_txid(&self, txid: Txid) -> Option<BlockHash> {


### PR DESCRIPTION
No need to use transaction cache for getting output values.