### PR TITLE
Split CI into build and integration jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,44 @@ name: electrs
 on: [push, pull_request]
 
 jobs:
-  electrs:
-    name: Electrum Integration Test
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          components: rustfmt, clippy
+          profile: minimal
+
+      - name: Format
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --locked --all
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --locked --all
+
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+
+  integration:
+    name: Integration
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- -D warnings
 
   integration:
     name: Integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,10 @@
 FROM rust:1.41.1-slim as electrs-build
 RUN apt-get update
 RUN apt-get install -qq -y clang cmake
-RUN rustup component add rustfmt clippy
 
-# Build, test and install electrs
+# Install electrs
 WORKDIR /build/electrs
 COPY . .
-RUN cargo fmt -- --check
-RUN cargo clippy
-RUN cargo build --locked --release --all
-RUN cargo test --locked --release --all
 RUN cargo install --locked --path .
 
 FROM debian:buster-slim as updated


### PR DESCRIPTION
Use debug build for build/clippy/fmt/unittests (using https://github.com/actions-rs).
Use release build for integration tests (using Docker).