### PR TITLE
Improve documentation of 0.8.x -> 0.9.0 upgrade

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,9 +1,22 @@
 # 0.9.0 (TBD)
 
+**IMPORTANT: This release contains major changes, please read carefully!**
+
+The two main things to watch out for:
+
+* Database schema changed - this will cause **reindex after upgrade**.
+* We now use **bitcoin p2p protocol** to fetch blocks - some configurations may not work.
+
+See [upgrading](doc/usage.md#upgrading) section of our docs to learn more.
+
+Full list of changes:
+
 * Fix incorrect ordering of same-block transactions (#297)
 * Change DB index format and use Zstd compression (instead of Snappy)
+* The database will be reindexed automatically when it encounters old version
 * Don't use bitcoind JSON RPC for fetching blocks (#373)
-* Use p2p for block fetching (instead of reading `blk*.dat` files)
+* Use p2p for block fetching only.
+  This is safer than reading `blk*dat` files and faster than Json RPC.
 * Support Electrum JSON RPC batching and errors
 * Use `rust-bitcoincore-rpc` crate
 * Increase default `index_lookup_limit` to 200

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,7 +13,7 @@ Full list of changes:
 
 * Fix incorrect ordering of same-block transactions (#297)
 * Change DB index format and use Zstd compression (instead of Snappy)
-* The database will be reindexed automatically when it encounters old version
+* The database will be reindexed automatically when it encounters old version (#477)
 * Don't use bitcoind JSON RPC for fetching blocks (#373)
 * Use p2p for block fetching only.
   This is safer than reading `blk*dat` files and faster than JSON RPC.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,7 +16,7 @@ Full list of changes:
 * The database will be reindexed automatically when it encounters old version
 * Don't use bitcoind JSON RPC for fetching blocks (#373)
 * Use p2p for block fetching only.
-  This is safer than reading `blk*dat` files and faster than Json RPC.
+  This is safer than reading `blk*dat` files and faster than JSON RPC.
 * Support Electrum JSON RPC batching and errors
 * Use `rust-bitcoincore-rpc` crate
 * Increase default `index_lookup_limit` to 200

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -487,16 +487,33 @@ $ ./contrib/history.sh 144STc7gcb9XCp6t4hvrcUEKg9KemivsCR
 
 ## Upgrading
 
-> Note that in 0.9.0 we have changed the RocksDB index format, so you may get an error when reading an older DB.
-> In this case, consider moving the old DB directory and perform a re-sync of the blockchain.
+### Important changes from versions older than 0.9.0
 
-> **If you're upgrading from version 0.8.7 to a higher version and used `cookie` option you should change your configuration!**
-> The `cookie` option was deprecated and **will be removed eventually**!
-> If you had actual cookie (from `~/bitcoin/.cookie` file) specified in `cookie` option, this was wrong as it wouldn't get updated when needed.
-> It's strongly recommended to use proper cookie authentication using `cookie_file`.
-> If you really have to use fixed username and password, explicitly specified in `bitcoind` config, use `auth` option instead.
-> Users of `btc-rpc-proxy` using `public:public` need to use `auth` too.
-> You can read [a detailed explanation of cookie deprecation with motivation explained](cookie_deprecation.md).
+In 0.9.0 we have changed the RocksDB index format to optimize electrs performance.
+We also use Bitcoin P2P protocol instead of reading blocks from disk or JSON RPC.
+ 
+Upgrading checklist:
+
+* Make sure you upgrade at time when you don't need to use electrs for a while.
+  Because of reindex electrs will be unable to serve your requests for a few hours.
+  (The exact time depends on your hardware.)
+  If you wish to check the database without reindexing run electrs with `--no-auto-reindex`.
+* Make sure to allow accesses to bitcoind from local address, ideally whitelist it using `whitelist=download@127.0.0.1` bitcoind option.
+  Either don't use `maxconnections` bitcoind option or set it to 12 or more.
+* If you use non-default P2P port for bitcoind adjust `electrs` configuration.
+* If you still didn't migrate `cookie` electrs option you have to now - see below.
+
+### Important changes from version older than 0.8.8
+
+**If you're upgrading from version 0.8.7 to a higher version and used `cookie` option you should change your configuration!**
+The `cookie` option was deprecated and **will be removed eventually**!
+If you had actual cookie (from `~/bitcoin/.cookie` file) specified in `cookie` option, this was wrong as it wouldn't get updated when needed.
+It's strongly recommended to use proper cookie authentication using `cookie_file`.
+If you really have to use fixed username and password, explicitly specified in `bitcoind` config, use `auth` option instead.
+Users of `btc-rpc-proxy` using `public:public` need to use `auth` too.
+You can read [a detailed explanation of cookie deprecation with motivation explained](cookie_deprecation.md).
+
+### General upgrading guide
 
 As with any other application, you need to remember how you installed `electrs` to upgrade it.
 If you don't then here's a little help: run `which electrs` and compare the output


### PR DESCRIPTION
This should hopefully make the major changes more visible and avoid
surprises.

Assumes #477 will get merged (in other words, don't merge before it)

Since this changes formatting & release notes significantly it felt more appropriate to open a separate PR.

I'm also thinking usage.md is quite large now, maybe split it up?