### PR TITLE
Don't fail if `wait_for_new_block` RPC timeouts

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -59,7 +59,13 @@ fn tip_receiver(config: &Config) -> Result<Receiver<BlockHash>> {
             Ok(_) | Err(TrySendError::Full(_)) => (),
             Err(TrySendError::Disconnected(_)) => bail!("tip receiver disconnected"),
         }
-        rpc.wait_for_new_block(duration)?;
+        if let Err(err) = rpc.wait_for_new_block(duration) {
+            warn!(
+                "waiting {:.1}s for new block failed: {}",
+                duration as f64 / 1e3,
+                err
+            );
+        }
     });
     Ok(tip_rx)
 }


### PR DESCRIPTION
Following #495.

`wait_duration_secs` is used for waiting for new blocks using `waitfornewblock` RPC:
https://github.com/bitcoin/bitcoin/blob/8f022a59b8bd7082a0336f5fb659dddd89d6ad66/src/rpc/blockchain.cpp#L283

IIUC, we call it with too large timeout, causing underlying JSON RPC framework to fail:
https://github.com/apoelstra/rust-jsonrpc/blob/64005f2896b98934e58c3a22f7d1430b110cb01a/src/simple_http.rs#L198
