### PR TITLE
Close index DB if interrupted during initial sync

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,7 @@
 
 * Prevent panic during logging of p2p messages (#490)
 * Don't collect process' Prometheus metrics by default (#492)
+* Support initial sync resume (#494)
 
 # 0.9.0-rc1 (Sep 17 2021)
 

--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -1,17 +1,13 @@
 #![recursion_limit = "256"]
 
 use anyhow::{Context, Result};
-use electrs::{server, Config, Daemon, Rpc, Tracker};
+use electrs::{server, Config, Rpc, Tracker};
 
 fn main() -> Result<()> {
     let config = Config::from_args();
-    let mut tracker = Tracker::new(&config)?;
-    tracker
-        .sync(&Daemon::connect(&config)?)
-        .context("initial sync failed")?;
+    let rpc = Rpc::new(&config, Tracker::new(&config)?)?;
     if config.sync_once {
         return Ok(());
     }
-    // re-connect after initial sync (due to possible timeout during compaction)
-    server::run(&config, Rpc::new(&config, tracker)?).context("server failed")
+    server::run(&config, rpc).context("server failed")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,4 @@ mod thread;
 mod tracker;
 mod types;
 
-pub use {
-    cache::Cache,
-    config::Config,
-    daemon::Daemon,
-    electrum::{Client, Rpc},
-    status::ScriptHashStatus,
-    tracker::Tracker,
-    types::ScriptHash,
-};
+pub use {config::Config, electrum::Rpc, tracker::Tracker};

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -3,30 +3,72 @@ use crossbeam_channel::{unbounded, Receiver};
 use signal_hook::consts::signal::*;
 use signal_hook::iterator::Signals;
 
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
 use crate::thread::spawn;
 
-pub(crate) enum Signal {
-    Exit,
-    Trigger,
+#[derive(Clone)]
+pub(crate) struct ExitFlag {
+    flag: Arc<AtomicBool>,
 }
 
-pub(crate) fn register() -> Receiver<Signal> {
-    let ids = [
-        SIGINT, SIGTERM,
-        SIGUSR1, // allow external triggering (e.g. via bitcoind `blocknotify`)
-    ];
-    let (tx, rx) = unbounded();
-    let mut signals = Signals::new(&ids).expect("failed to register signal hook");
-    spawn("signal", move || {
-        for id in &mut signals {
-            info!("notified via SIG{}", id);
-            let signal = match id {
-                SIGUSR1 => Signal::Trigger,
-                _ => Signal::Exit,
-            };
-            tx.send(signal).context("failed to send signal")?;
+impl ExitFlag {
+    fn new() -> Self {
+        ExitFlag {
+            flag: Arc::new(AtomicBool::new(false)),
         }
-        Ok(())
-    });
-    rx
+    }
+
+    pub fn is_set(&self) -> bool {
+        self.flag.load(Ordering::Relaxed)
+    }
+
+    fn set(&self) {
+        self.flag.store(true, Ordering::Relaxed)
+    }
+}
+
+pub(crate) struct Signal {
+    rx: Receiver<()>,
+    exit: ExitFlag,
+}
+
+impl Signal {
+    pub fn new() -> Signal {
+        let ids = [
+            SIGINT, SIGTERM,
+            SIGUSR1, // allow external triggering (e.g. via bitcoind `blocknotify`)
+        ];
+        let (tx, rx) = unbounded();
+        let result = Signal {
+            rx,
+            exit: ExitFlag::new(),
+        };
+
+        let exit_flag = result.exit.clone();
+        let mut signals = Signals::new(&ids).expect("failed to register signal hook");
+        spawn("signal", move || {
+            for id in &mut signals {
+                info!("notified via SIG{}", id);
+                match id {
+                    SIGUSR1 => (),
+                    _ => exit_flag.set(),
+                };
+                tx.send(()).context("failed to send signal")?;
+            }
+            Ok(())
+        });
+        result
+    }
+
+    pub fn receiver(&self) -> &Receiver<()> {
+        &self.rx
+    }
+
+    pub fn exit_flag(&self) -> &ExitFlag {
+        &self.exit
+    }
 }

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -10,6 +10,7 @@ use crate::{
     index::Index,
     mempool::{Histogram, Mempool},
     metrics::Metrics,
+    signals::ExitFlag,
     status::{Balance, HistoryEntry, ScriptHashStatus, UnspentEntry},
 };
 
@@ -61,8 +62,8 @@ impl Tracker {
         status.get_unspent(self.index.chain())
     }
 
-    pub fn sync(&mut self, daemon: &Daemon) -> Result<()> {
-        self.index.sync(daemon)?;
+    pub(crate) fn sync(&mut self, daemon: &Daemon, exit_flag: &ExitFlag) -> Result<()> {
+        self.index.sync(daemon, exit_flag)?;
         if !self.ignore_mempool {
             self.mempool.sync(daemon);
         }
@@ -85,7 +86,7 @@ impl Tracker {
         status.get_balance(self.chain())
     }
 
-    pub fn get_blockhash_by_txid(&self, txid: Txid) -> Option<BlockHash> {
+    pub(crate) fn get_blockhash_by_txid(&self, txid: Txid) -> Option<BlockHash> {
         // Note: there are two blocks with coinbase transactions having same txid (see BIP-30)
         self.index.filter_by_txid(txid).next()
     }


### PR DESCRIPTION
It should allow resuming initial sync (fixing #494).

Also, refactor `index_batch_size` usage.