### PR TITLE
Disable setting TRACE verbosity by '-vvvv'

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -31,6 +31,7 @@ Full list of changes:
 * Increase default `index_lookup_limit` to 200
 * Implement 'blockchain.scripthash.listunspent' RPC (#475)
 * Update RocksDB to 6.11.4 (#473)
+* Allow logging configuration via `RUST_LOG` environment variable (using `env_logger`)
 
 # 0.8.12 (14 Sep 2021)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -276,8 +276,7 @@ impl Config {
             0 => log::LevelFilter::Error,
             1 => log::LevelFilter::Warn,
             2 => log::LevelFilter::Info,
-            3 => log::LevelFilter::Debug,
-            _ => log::LevelFilter::Trace,
+            _ => log::LevelFilter::Debug,
         };
 
         let index_lookup_limit = match config.index_lookup_limit {


### PR DESCRIPTION
Should fix https://github.com/romanz/electrs/issues/355#issuecomment-926903119.

It still can be set using:
```
RUST_LOG=electrs=TRACE target/release/electrs <args>
```

See https://docs.rs/env_logger for more usage examples.