### PR TITLE
Initialize chain height metric

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -86,12 +86,15 @@ impl Index {
             chain.load(headers, tip);
         };
 
+        let stats = Stats::new(metrics);
+        stats.height.set(chain.height());
+
         Ok(Index {
             store,
             batch_size,
             lookup_limit,
             chain,
-            stats: Stats::new(metrics),
+            stats,
         })
     }
 


### PR DESCRIPTION
Otherwise, it will be 0 until the a new block is indexed.

Following https://github.com/romanz/electrs/issues/505#issuecomment-930651597.