### PR TITLE
Clarify upgrading to 0.9.0

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -512,8 +512,10 @@ Upgrading checklist:
   since in the worst case scenario you will run out of space in ~69 days.
 * Make sure to allow accesses to bitcoind from local address, ideally whitelist it using `whitelist=download@127.0.0.1` bitcoind option.
   Either don't use `maxconnections` bitcoind option or set it to 12 or more.
-* If you use non-default P2P port for bitcoind adjust `electrs` configuration.
+* If you use non-default P2P port (or address) for bitcoind adjust `electrs` configuration.
 * If you still didn't migrate `cookie` electrs option you have to now - see below.
+* Remove unsupported options from configuration (`blocks_dir`, `jsonrpc_import`, `bulk_index_threads`, `tx_cache_size_mb`, `blocktxids_cache_size_mb`)
+* Rename `txid_limit` to `index_lookup_limit` iif used
 * If you use `verbose = 4` (or `-vvvv` argument) lower it down to `2` (`-vv`) for production use.
   Keeping it would waste resources because we utilize it more now.
 * **After reindexing**, if you did **not** delete `mainnet` subdirectory within `db_dir` check that `electrs` works as expected and then *delete whole `mainnet` subdirectory*.


### PR DESCRIPTION
Removing/renaming unsupported switches was not called out explicitly and it's possible that someone is using a different bitcoind address, not just port.

Closes #520