### PR TITLE
Don't shutdown write-side before all responses are sent back

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -43,7 +43,9 @@ impl Peer {
     }
 
     fn disconnect(self) {
-        let _ = self.stream.shutdown(Shutdown::Both);
+        if let Err(e) = self.stream.shutdown(Shutdown::Both) {
+            warn!("{}: failed to shutdown TCP connection {}", self.id, e)
+        }
     }
 }
 
@@ -196,7 +198,9 @@ fn accept_loop(listener: TcpListener, server_tx: Sender<Event>) -> Result<()> {
         let tx = server_tx.clone();
         spawn("recv_loop", move || {
             let result = recv_loop(peer_id, &stream, tx);
-            let _ = stream.shutdown(Shutdown::Read);
+            if let Err(e) = stream.shutdown(Shutdown::Read) {
+                warn!("{}: failed to shutdown TCP receiving {}", peer_id, e)
+            }
             result
         });
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -196,7 +196,7 @@ fn accept_loop(listener: TcpListener, server_tx: Sender<Event>) -> Result<()> {
         let tx = server_tx.clone();
         spawn("recv_loop", move || {
             let result = recv_loop(peer_id, &stream, tx);
-            let _ = stream.shutdown(Shutdown::Both);
+            let _ = stream.shutdown(Shutdown::Read);
             result
         });
     }


### PR DESCRIPTION
Otherwise, the server fails to send RPC result to the client:
https://github.com/romanz/electrs/issues/508#issuecomment-928254892

The bug can be reproduced on testnet using:
```python
$ cat test.py 
import socket
import sys
import time

s = socket.create_connection(('localhost', 60001))
s.sendall(b'{"jsonrpc": "2.0", "method": "blockchain.scripthash.subscribe", "params": ["93df2ed6d3031610206a9ef6ee5d7c2bc538d6689ffb5ce964144b2b90bdc9e1"], "id": 1}\n')
s.shutdown(socket.SHUT_WR)  # the server should stop "receiver loop" now, but not drop the connection

time.sleep(1)
print(s.recv(1000))
```
The server fails to send the response:
```
[2021-09-30T17:51:14.361Z ERROR electrs::server] 0: disconnecting due to failed to send response: "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":\"f7dd2df65f0eb38f413b46c242a9b11da184aada073d797fde3ce32fb33f107e\"}\n"
```

After this fix, the response should be received correctly by the client.