### PR TITLE
Allow reindexing last blocks, mainly for sync logic testing

### DIFF
--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -111,6 +111,12 @@ doc = "Number of transactions to lookup before returning an error, to prevent 't
 default = "200"
 
 [[param]]
+name = "reindex_last_blocks"
+type = "usize"
+doc = "Number of last blocks to reindex (used for testing)"
+default = "0"
+
+[[param]]
 name = "server_banner"
 type = "String"
 doc = "The banner to be shown in the Electrum console"

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ const DEFAULT_SERVER_ADDRESS: [u8; 4] = [127, 0, 0, 1]; // by default, serve on 
 mod internal {
     #![allow(unused)]
     #![allow(clippy::identity_conversion)]
+    #![allow(clippy::cognitive_complexity)]
 
     include!(concat!(env!("OUT_DIR"), "/configure_me_config.rs"));
 }
@@ -133,6 +134,7 @@ pub struct Config {
     pub jsonrpc_timeout: Duration,
     pub index_batch_size: usize,
     pub index_lookup_limit: Option<usize>,
+    pub reindex_last_blocks: usize,
     pub auto_reindex: bool,
     pub ignore_mempool: bool,
     pub sync_once: bool,
@@ -306,6 +308,7 @@ impl Config {
             jsonrpc_timeout: Duration::from_secs(config.jsonrpc_timeout_secs),
             index_batch_size: config.index_batch_size,
             index_lookup_limit,
+            reindex_last_blocks: config.reindex_last_blocks,
             auto_reindex: config.auto_reindex,
             ignore_mempool: config.ignore_mempool,
             sync_once: config.sync_once,

--- a/src/index.rs
+++ b/src/index.rs
@@ -79,6 +79,7 @@ impl Index {
         metrics: &Metrics,
         batch_size: usize,
         lookup_limit: Option<usize>,
+        reindex_last_blocks: usize,
     ) -> Result<Self> {
         if let Some(row) = store.get_tip() {
             let tip = deserialize(&row).expect("invalid tip");
@@ -88,6 +89,7 @@ impl Index {
                 .map(|row| HeaderRow::from_db_row(&row).header)
                 .collect();
             chain.load(headers, tip);
+            chain.drop_last_headers(reindex_last_blocks);
         };
 
         let stats = Stats::new(metrics);

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -34,6 +34,7 @@ impl Tracker {
                 &metrics,
                 config.index_batch_size,
                 config.index_lookup_limit,
+                config.reindex_last_blocks,
             )
             .context("failed to open index")?,
             mempool: Mempool::new(),


### PR DESCRIPTION
Also, added clippy exception for:
```
warning: the function has a cognitive complexity of (26/25)
   --> ./electrs/target/release/build/electrs-600a795995255594/out/configure_me_config.rs:453:9
    |
453 | /         pub fn merge_args<I: IntoIterator<Item=::std::ffi::OsString>>(&mut self, args: I) -> Result<impl Iterator<Item=::std::ffi::OsString>, super::Error> {
454 | |             let mut iter = args.into_iter().fuse();
455 | |             self._program_path = iter.next().map(Into::into);
456 | |
...   |
571 | |             Ok(None.into_iter().chain(iter))
572 | |         }
    | |_________^
    |
    = note: `#[warn(clippy::cognitive_complexity)]` on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cognitive_complexity
```