### PR TITLE
Add electrs version to p2p 'user_agent'

### DIFF
--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -22,6 +22,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
     chain::{Chain, NewHeader},
+    config::ELECTRS_VERSION,
     metrics::{default_duration_buckets, default_size_buckets, Histogram, Metrics},
 };
 
@@ -305,7 +306,7 @@ fn build_version_message() -> NetworkMessage {
         receiver: address::Address::new(&addr, services),
         sender: address::Address::new(&addr, services),
         nonce: secp256k1::rand::thread_rng().gen(),
-        user_agent: String::from("electrs"),
+        user_agent: format!("/electrs:{}/", ELECTRS_VERSION),
         start_height: 0,
         relay: false,
     })


### PR DESCRIPTION
Can be retrievied using `bitcoin-cli getpeerinfo`:
```json
 {
    "id": 19,
    "addr": "127.0.0.1:34280",
    "addrbind": "127.0.0.1:38333",
    "network": "not_publicly_routable",
    "services": "0000000000000000",
    "servicesnames": [],
    "relaytxes": false,
    "lastsend": 1634808320,
    "lastrecv": 1634808320,
    "last_transaction": 0,
    "last_block": 0,
    "bytessent": 1183,
    "bytesrecv": 2921,
    "conntime": 1634808309,
    "timeoffset": 0,
    "pingtime": 0.000146,
    "minping": 0.000146,
    "version": 70001,
    "subver": "/electrs:0.9.1/",
    "inbound": true,
    "bip152_hb_to": false,
    "bip152_hb_from": false,
    "startingheight": 0,
    "synced_headers": -1,
    "synced_blocks": -1,
    "inflight": [],
    "addr_relay_enabled": false,
    "addr_processed": 0,
    "addr_rate_limited": 0,
    "permissions": [],
    "minfeefilter": 0,
    "bytessent_per_msg": {
      "alert": 192,
      "block": 652,
      "headers": 156,
      "ping": 32,
      "verack": 24,
      "version": 127
    },
    "bytesrecv_per_msg": {
      "getdata": 61,
      "getheaders": 2679,
      "pong": 32,
      "verack": 24,
      "version": 125
    },
    "connection_type": "inbound"
  }
```