### PR TITLE
Add possibility to print out the program version without actually running it

### DIFF
--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -108,6 +108,10 @@ doc = "Exit after the initial sync is over (don't start Electrum server)."
 name = "cache_merkle_proofs"
 doc = "Cache merkle proofs on subscription (if disabled, they are computed on demand)."
 
+[[switch]]
+name = "version"
+doc = "Print out the program version."
+
 [[param]]
 name = "index_lookup_limit"
 type = "usize"

--- a/src/config.rs
+++ b/src/config.rs
@@ -308,6 +308,11 @@ impl Config {
             std::process::exit(1);
         }
 
+        if config.version {
+            println!("v{}", ELECTRS_VERSION);
+            std::process::exit(0);
+        }
+
         let config = Config {
             network: config.network,
             db_path: config.db_dir,


### PR DESCRIPTION
This pull request adds a possiblity to print out the current program version and exit immediately.

There are cases where I need to grab versions of multiple apps on my system. It would be great if I could get electrs version without parsing its logs (`Starting electrs 0.9.2 on x86_64 linux with Config { network: Bitcoin...`).

This is for example also handy when I update nix packages on my `nix-bitcoin` node and I need to recheck the program versions before actually switching to them (`nixos-rebuild switch`).