### PR TITLE
Remove `verbose` configuration

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,7 @@
 * Monitor RocksDB statistics via Prometheus (#605)
 * Don't warn when queried with unsubscribed scripthashes (#609)
 * Allow skipping merkle proofs' during subscription (#610)
+* Remove `verbose` configuration (#615)
 
 # 0.9.2 (Oct 31 2021)
 

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -1,3 +1,9 @@
+### Important changes from versions older than 0.9.3
+
+* If you use `verbose` (or `-v` argument), switch to `log_filters` (or `RUST_LOG` environment variable).
+  Please note that it allows to set per-module filters, but module naming is considered unstable.
+
+
 ### Important changes from versions older than 0.9.0
 
 In 0.9.0 we have changed the RocksDB index format to optimize electrs performance.

--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -125,3 +125,8 @@ name = "server_banner"
 type = "String"
 doc = "The banner to be shown in the Electrum console"
 default = "concat!(\"Welcome to electrs \", env!(\"CARGO_PKG_VERSION\"), \" (Electrum Rust Server)!\").to_owned()"
+
+[[param]]
+name = "log_filters"
+type = "String"
+doc = "Logging filters, overriding `RUST_LOG` environment variable (see https://docs.rs/env_logger/ for details)"

--- a/src/config.rs
+++ b/src/config.rs
@@ -287,12 +287,10 @@ impl Config {
             }
         });
 
-        let level = match config.verbose {
-            0 => log::LevelFilter::Error,
-            1 => log::LevelFilter::Warn,
-            2 => log::LevelFilter::Info,
-            _ => log::LevelFilter::Debug,
-        };
+        if config.verbose > 0 {
+            eprintln!("Error: please use `log_filter` to set logging verbosity",);
+            std::process::exit(1);
+        }
 
         let index_lookup_limit = match config.index_lookup_limit {
             0 => None,
@@ -340,7 +338,6 @@ impl Config {
         env_logger::Builder::from_default_env()
             .default_format()
             .format_timestamp_millis()
-            .filter_level(level)
             .init();
         config
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -288,9 +288,10 @@ impl Config {
         });
 
         if config.verbose > 0 {
-            eprintln!("Error: please use `log_filter` to set logging verbosity",);
+            eprintln!("Error: please use `log_filters` to set logging verbosity",);
             std::process::exit(1);
         }
+        let log_filters = config.log_filters;
 
         let index_lookup_limit = match config.index_lookup_limit {
             0 => None,
@@ -335,10 +336,13 @@ impl Config {
             "Starting electrs {} on {} {} with {:?}",
             ELECTRS_VERSION, ARCH, OS, config
         );
-        env_logger::Builder::from_default_env()
-            .default_format()
-            .format_timestamp_millis()
-            .init();
+        let mut builder = env_logger::Builder::from_default_env();
+        builder.default_format().format_timestamp_millis();
+        if let Some(log_filters) = &log_filters {
+            builder.parse_filters(log_filters);
+        }
+        builder.init();
+
         config
     }
 }


### PR DESCRIPTION
Please use `RUST_LOG` to specify logging verbosity.
See https://github.com/env-logger-rs/env_logger/ for details.