### PR TITLE
Add dependabot config for autmatic cargo update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Merging this opens update PRs like they can be seen here https://github.com/dbast/electrs/pulls

Proposed updates can be merged if CI is green or closed to be ignored.

There are also commands to tell dependabot e.g. to ignore specific major versions `@dependabot ignore this major version` as described in the PRs.