### PR TITLE
Dockerfile: re-add curl, so it can be used for docker health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM debian:bullseye-slim as base
 RUN apt-get update -qqy
-RUN apt-get install -qqy librocksdb-dev=6.11.4-3
+RUN apt-get install -qqy librocksdb-dev=6.11.4-3 curl
 
 ### Electrum Rust Server ###
 FROM base as electrs-build


### PR DESCRIPTION
Note: I've decided to not add a default health check to the Dockerfile, since the monitoring port is different for each network. I could add a default for mainnet, but then by default testnet and signet installations would be unhealthy.

If you want to add a health check to your docker-compose.yaml, you can use:

```
    healthcheck:
      test: ["CMD-SHELL", "curl -fSs http://localhost:4224/ || exit 1"]
```