### PR TITLE
Warn on attempt to connect over SSL

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -9,6 +9,7 @@ where
         .spawn(move || {
             if let Err(e) = f() {
                 warn!("{} thread failed: {}", name, e);
+                e.chain().skip(1).for_each(|e| warn!("because: {}", e));
             }
         })
         .expect("failed to spawn a thread")


### PR DESCRIPTION
Usecase: I was changing my client & server configuration around a lot (trying raw Bitcoin Core, turning on/off Tor etc) and ended up trying to connect with SSL activated on the client but without running Electrs behind Nginx. Naturally it failed, but to save my future self or the next person some time, I suggest adding a clear warning in the log.

Feel free to tidy up the change or instruct me in how to best improve it. My Rust-fu is weak.