### PR TITLE
Use configure_me to skip default config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "configure_me_codegen"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ddbd860cbff075ceadf4714922a73afbe8bf53d9ed9add6c6b733feeb6f3c7"
+checksum = "9aa65df44cc55922b4e22f49939727156a8de25492bf6bd2462a75afc5e155d6"
 dependencies = [
  "cargo_toml",
  "fmt2io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ build = "build.rs"
 default = ["metrics"]
 metrics = ["prometheus", "tiny_http"]
 metrics_process = ["prometheus/process"]
-ignore_default_config_files = []
 
 [package.metadata.configure_me]
 spec = "internal/config_specification.toml"
@@ -51,7 +50,7 @@ default-features = false
 features = ["zstd", "snappy"]
 
 [build-dependencies]
-configure_me_codegen = "0.4"
+configure_me_codegen = "0.4.2"
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -2,6 +2,7 @@
 env_prefix = "ELECTRS"
 conf_file_param = "conf"
 conf_dir_param = "conf_dir"
+skip_default_conf_files_switch = "skip_default_conf_files"
 doc = """
 An efficient re-implementation of Electrum Server, inspired by ElectrumX, Electrum Personal Server and bitcoincore-indexd.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -178,21 +178,13 @@ fn default_daemon_dir() -> PathBuf {
 }
 
 fn default_config_files() -> Vec<OsString> {
-    #[cfg(not(feature = "ignore_default_config_files"))]
-    {
-        let mut files = vec![OsString::from("electrs.toml")]; // cwd
-        if let Some(mut path) = home_dir() {
-            path.extend(&[".electrs", "config.toml"]);
-            files.push(OsString::from(path)) // home directory
-        }
-        files.push(OsString::from("/etc/electrs/config.toml")); // system-wide
-        files
+    let mut files = vec![OsString::from("electrs.toml")]; // cwd
+    if let Some(mut path) = home_dir() {
+        path.extend(&[".electrs", "config.toml"]);
+        files.push(OsString::from(path)) // home directory
     }
-
-    #[cfg(feature = "ignore_default_config_files")]
-    {
-        vec![]
-    }
+    files.push(OsString::from("/etc/electrs/config.toml")); // system-wide
+    files
 }
 
 impl Config {


### PR DESCRIPTION
This removes the feature for skipping default config files and replaces
it with a configure_me implementation.

Closes #217

~~Note: `cfg_me` supporting this will be released soon.~~ Done.
Sorry for this taking so long time.