### PR TITLE
WIP: Feature/custom signet

### DIFF
--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -131,3 +131,8 @@ default = "concat!(\"Welcome to electrs \", env!(\"CARGO_PKG_VERSION\"), \" (Ele
 name = "log_filters"
 type = "String"
 doc = "Logging filters, overriding `RUST_LOG` environment variable (see https://docs.rs/env_logger/ for details)"
+
+[[param]]
+name = "signet_magic"
+type = "u32"
+doc = "network magic for custom signet network (signet only)"

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,6 +144,7 @@ pub struct Config {
     pub sync_once: bool,
     pub disable_electrum_rpc: bool,
     pub server_banner: String,
+    pub signet_magic: u32,
     pub args: Vec<String>,
 }
 
@@ -229,6 +230,15 @@ impl Config {
             Network::Testnet => 14224,
             Network::Regtest => 24224,
             Network::Signet => 34224,
+        };
+
+        let magic = match (config.network, config.signet_magic) {
+            (Network::Signet, Some(magic)) => magic,
+            (network, None) => network.magic(),
+            (_, Some(_)) => {
+                eprintln!("Error: signet magic only available on signet");
+                std::process::exit(1);
+            },
         };
 
         let daemon_rpc_addr: SocketAddr = config.daemon_rpc_addr.map_or(
@@ -323,6 +333,7 @@ impl Config {
             sync_once: config.sync_once,
             disable_electrum_rpc: config.disable_electrum_rpc,
             server_banner: config.server_banner,
+            signet_magic: magic,
             args: args.map(|a| a.into_string().unwrap()).collect(),
         };
         eprintln!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,7 +238,7 @@ impl Config {
             (_, Some(_)) => {
                 eprintln!("Error: signet magic only available on signet");
                 std::process::exit(1);
-            },
+            }
         };
 
         let daemon_rpc_addr: SocketAddr = config.daemon_rpc_addr.map_or(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -137,6 +137,7 @@ impl Daemon {
             config.network,
             config.daemon_p2p_addr,
             metrics,
+            config.signet_magic,
         )?);
         Ok(Self { p2p, rpc })
     }

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -128,6 +128,7 @@ impl Connection {
         network: Network,
         address: SocketAddr,
         metrics: &Metrics,
+        magic: u32,
     ) -> Result<Self> {
         let conn = Arc::new(
             TcpStream::connect(address)
@@ -186,7 +187,7 @@ impl Connection {
             send_duration.observe_duration("send", || {
                 trace!("send: {:?}", msg);
                 let raw_msg = message::RawNetworkMessage {
-                    magic: network.magic(),
+                    magic: magic,
                     payload: msg,
                 };
                 (&*stream)
@@ -212,7 +213,7 @@ impl Connection {
             }
             let raw_msg = match raw_msg {
                 Ok(raw_msg) => {
-                    assert_eq!(raw_msg.magic, network.magic());
+                    assert_eq!(raw_msg.magic, magic);
                     recv_size.observe(raw_msg.cmd.as_ref(), raw_msg.raw.len() as f64);
                     raw_msg
                 }

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -187,7 +187,7 @@ impl Connection {
             send_duration.observe_duration("send", || {
                 trace!("send: {:?}", msg);
                 let raw_msg = message::RawNetworkMessage {
-                    magic: magic,
+                    magic,
                     payload: msg,
                 };
                 (&*stream)


### PR DESCRIPTION
This PR attempts to solve the issue raised in #418 
It is pretty straightforward, a `signet_magic` can be added as an option. If it is not set the magic is the default value for the network (`network.magic()`).
It is not fully operational though, I tried to run it against a custom signet and it seems that it downloads some blocks then fails for some reason. Here's the full log of a typical run:
```
Starting electrs 0.9.8 on x86_64 linux with Config { network: Signet, db_path: "/home/electrs/db/signet", daemon_dir: "/data/signet", daemon_auth: CookieFile("/data/signet/.cookie"), daemon_rpc_addr: 192.168.240.3:38332, daemon_p2p_addr: 192.168.240.3:38333, electrum_rpc_addr: 127.0.0.1:60601, monitoring_addr: 127.0.0.1:34224, wait_duration: 10s, jsonrpc_timeout: 15s, index_batch_size: 10, index_lookup_limit: None, reindex_last_blocks: 0, auto_reindex: true, ignore_mempool: false, sync_once: false, disable_electrum_rpc: false, server_banner: "Welcome to electrs 0.9.8 (Electrum Rust Server)!", signet_magic: 3278571876, args: [] }
[2022-08-16T13:50:01.595Z INFO  electrs::metrics::metrics_impl] serving Prometheus metrics on 127.0.0.1:34224
[2022-08-16T13:50:01.595Z INFO  electrs::server] serving Electrum RPC on 127.0.0.1:60601
[2022-08-16T13:50:01.601Z DEBUG tiny_http] Server listening on 127.0.0.1:34224
[2022-08-16T13:50:01.606Z DEBUG tiny_http] Running accept thread
[2022-08-16T13:50:01.670Z INFO  electrs::db] "/home/electrs/db/signet": 13 SST files, 0.000010465 GB, 0.000000013 Grows
[2022-08-16T13:50:01.670Z DEBUG electrs::db] DB Some(Config { compacted: false, format: 0 })
[2022-08-16T13:50:01.688Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:01.689Z DEBUG bitcoincore_rpc] JSON-RPC error for getblockchaininfo: RpcError { code: -28, message: "Loading wallet…", data: None }
[2022-08-16T13:50:01.689Z INFO  electrs::daemon] waiting for RPC warmup: Loading wallet…
[2022-08-16T13:50:02.691Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:02.692Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:02.692Z INFO  electrs::daemon] waiting for 117 blocks to download
[2022-08-16T13:50:03.692Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:03.722Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:03.723Z INFO  electrs::daemon] waiting for 96 blocks to download
[2022-08-16T13:50:04.729Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:04.730Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:04.771Z INFO  electrs::daemon] waiting for 85 blocks to download
[2022-08-16T13:50:05.778Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:05.799Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:05.800Z INFO  electrs::daemon] waiting for 69 blocks to download
[2022-08-16T13:50:06.814Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:06.829Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:06.830Z INFO  electrs::daemon] waiting for 56 blocks to download
[2022-08-16T13:50:07.832Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:07.834Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:07.835Z INFO  electrs::daemon] waiting for 45 blocks to download
[2022-08-16T13:50:08.836Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:08.837Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:08.838Z INFO  electrs::daemon] waiting for 34 blocks to download
[2022-08-16T13:50:09.840Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:09.858Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:09.859Z INFO  electrs::daemon] waiting for 23 blocks to download
[2022-08-16T13:50:10.861Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:10.958Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:10.960Z INFO  electrs::daemon] waiting for 2 blocks to download
[2022-08-16T13:50:11.975Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:11.977Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:11.978Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:11.978Z DEBUG bitcoincore_rpc] JSON-RPC request: getblockchaininfo []
[2022-08-16T13:50:11.979Z DEBUG bitcoincore_rpc] JSON-RPC request: getnetworkinfo []
[2022-08-16T13:50:11.981Z DEBUG electrs::p2p] closing p2p_recv thread: connection closed
[2022-08-16T13:50:11.981Z DEBUG electrs::p2p] closing p2p_loop thread: peer has disconnected
[2022-08-16T13:50:11.981Z INFO  electrs::db] closing DB at /home/electrs/db/signet
Error: electrs failed

Caused by:
    receiving on an empty and disconnected channel
```

I run electrs and bitcoin core in a docker compose. 

[EDIT]
Here's bitcoin log:
```
2022-08-16T13:55:47Z Added connection peer=2
2022-08-16T13:55:47Z connection from 192.168.240.6:57364 accepted
2022-08-16T13:55:47Z Header error: Wrong MessageStart 64096bc3 received, peer=2
2022-08-16T13:55:47Z disconnecting peer=2
2022-08-16T13:55:47Z Cleared nodestate for peer=2
2022-08-16T13:56:02Z sending ping (8 bytes) peer=0
2022-08-16T13:56:02Z received: pong (8 bytes) peer=0
2022-08-16T13:56:02Z received: ping (8 bytes) peer=0
2022-08-16T13:56:02Z sending pong (8 bytes) peer=0
2022-08-16T13:56:33Z received: cmpctblock (332 bytes) peer=0
```
So I have the bad magic? I got it from the logs, but I must have missed something