### PR TITLE
Takes signet magic in hex as in bitcoin core logs

### DIFF
--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -134,5 +134,5 @@ doc = "Logging filters, overriding `RUST_LOG` environment variable (see https://
 
 [[param]]
 name = "signet_magic"
-type = "u32"
-doc = "network magic for custom signet network (signet only)"
+type = "String"
+doc = "network magic for custom signet network in hex format, as found in Bitcoin Core logs (signet only)"

--- a/src/config.rs
+++ b/src/config.rs
@@ -234,7 +234,7 @@ impl Config {
 
         let magic = match (config.network, config.signet_magic) {
             (Network::Signet, Some(magic)) => u32::from_str_radix(&magic, 16)
-                .expect("Invalid hex string")
+                .expect("Invalid signet hex magic")
                 .swap_bytes(),
             (network, None) => network.magic(),
             (_, Some(_)) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -233,7 +233,9 @@ impl Config {
         };
 
         let magic = match (config.network, config.signet_magic) {
-            (Network::Signet, Some(magic)) => magic,
+            (Network::Signet, Some(magic)) => u32::from_str_radix(&magic, 16)
+                .expect("Invalid hex string")
+                .swap_bytes(),
             (network, None) => network.magic(),
             (_, Some(_)) => {
                 eprintln!("Error: signet magic only available on signet");


### PR DESCRIPTION
This is a follow-up on #762, to allow the `signet-magic` option to be passed as the hex string that is found in Bitcoin Core logs.

Previously the magic was passed directly as a u32, which was cumbersome as user had to manually reverse the bytes in the magic given by Core and convert it to an int.

With this PR, you can grep `magic` in Bitcoin Core logs (let's say it's `deadbeef`), and then directly pass it as argument `--signet-magic deadbeef`. Previously you would have to first figure out that it corresponds to `4022250974`.

I should have directly made it like that sorry. 