### PR TITLE
RUSTSEC-2020-0159 is no longer an issue

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,3 +1,1 @@
 [advisories]
-
-ignore = ["RUSTSEC-2020-0159"]


### PR DESCRIPTION
Following https://github.com/romanz/electrs/pull/775