### PR TITLE
Experiment: Update configure me codegen with more `allow` attributes removed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "configure_me_codegen"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa65df44cc55922b4e22f49939727156a8de25492bf6bd2462a75afc5e155d6"
+checksum = "981fb98983781be95b91dc4ce7c178ae000f91350d783d43d1ce8adc4963c91f"
 dependencies = [
  "cargo_toml",
  "fmt2io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ default-features = false
 features = ["zstd", "snappy"]
 
 [build-dependencies]
-configure_me_codegen = "0.4.2"
+configure_me_codegen = "0.4.3"
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate configure_me_codegen;
-
-fn main() -> Result<(), configure_me_codegen::Error> {
-    configure_me_codegen::build_script_auto()
+fn main() {
+    configure_me_codegen::build_script_auto().unwrap_or_else(|error| error.report_and_exit())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,10 +16,7 @@ pub const ELECTRS_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_SERVER_ADDRESS: [u8; 4] = [127, 0, 0, 1]; // by default, serve on IPv4 localhost
 
 mod internal {
-    #![allow(clippy::cognitive_complexity)]
     #![allow(clippy::enum_variant_names)]
-    #![allow(clippy::unnecessary_lazy_evaluations)]
-    #![allow(clippy::useless_conversion)]
 
     include!(concat!(env!("OUT_DIR"), "/configure_me_config.rs"));
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,6 @@ pub const ELECTRS_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_SERVER_ADDRESS: [u8; 4] = [127, 0, 0, 1]; // by default, serve on IPv4 localhost
 
 mod internal {
-    #![allow(unused)]
     #![allow(clippy::cognitive_complexity)]
     #![allow(clippy::enum_variant_names)]
     #![allow(clippy::unnecessary_lazy_evaluations)]


### PR DESCRIPTION
These should not be needed with newer version of `configure_me_codegen`
but not sure. Let's make the CI do the work of figuring out.