### PR TITLE
Disable cargo-bloat action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,18 +61,6 @@ jobs:
           command: clippy
           args: -- -D warnings
 
-      - name: Install cargo-bloat
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-bloat
-
-      - name: Run cargo-bloat
-        uses: actions-rs/cargo@v1
-        with:
-          command: bloat
-          args: --locked --all --release --crates --time
-
   integration:
     name: Integration
     runs-on: ubuntu-latest


### PR DESCRIPTION
It takes ~10m on GitHub CI.