### PR TITLE
WIP upgrade with Magic type

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use bitcoin::network::constants::Network;
+use bitcoin::network::constants::{Magic, Network};
 use bitcoincore_rpc::Auth;
 use dirs_next::home_dir;
 
@@ -142,7 +142,7 @@ pub struct Config {
     pub sync_once: bool,
     pub disable_electrum_rpc: bool,
     pub server_banner: String,
-    pub signet_magic: bitcoin::network::Magic,
+    pub signet_magic: Magic,
     pub args: Vec<String>,
 }
 

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -7,7 +7,8 @@ use bitcoin::{
     },
     hashes::Hash,
     network::{
-        address, constants,
+        address,
+        constants::{self, Magic},
         message::{self, CommandString, NetworkMessage},
         message_blockdata::{GetHeadersMessage, Inventory},
         message_network,
@@ -130,7 +131,7 @@ impl Connection {
         network: Network,
         address: SocketAddr,
         metrics: &Metrics,
-        magic: bitcoin::network::Magic,
+        magic: Magic,
     ) -> Result<Self> {
         let conn = Arc::new(
             TcpStream::connect(address)
@@ -337,7 +338,7 @@ fn build_version_message() -> NetworkMessage {
 }
 
 struct RawNetworkMessage {
-    magic: bitcoin::network::Magic,
+    magic: Magic,
     cmd: CommandString,
     raw: Vec<u8>,
 }


### PR DESCRIPTION
This is a follow-up of #768 
Since then rust-bitcoin has merged a [PR](https://github.com/rust-bitcoin/rust-bitcoin/pull/1288) that creates a new `Magic` type and modifies the api.
This PR is only a WIP/placeholder while the change is not tagged in a version of rust-bitcoin, its scope is only the necessary changes to make it work with the new way rust-bitcoin handles network's magic.