### PR TITLE
Implement `blockchain.transaction.id_from_pos` RPC

### DIFF
--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -16,7 +16,7 @@ use crate::{
     cache::Cache,
     config::{Config, ELECTRS_VERSION},
     daemon::{self, extract_bitcoind_error, Daemon},
-    merkle::{Proof},
+    merkle::Proof,
     metrics::{self, Histogram, Metrics},
     signals::Signal,
     status::ScriptHashStatus,
@@ -401,14 +401,17 @@ impl Rpc {
         }
     }
 
-    fn transaction_from_pos(&self, (height, tx_pos, merkle): &(usize, usize, bool)) -> Result<Value> {
+    fn transaction_from_pos(
+        &self,
+        (height, tx_pos, merkle): &(usize, usize, bool),
+    ) -> Result<Value> {
         let chain = self.tracker.chain();
         let blockhash = match chain.get_block_hash(*height) {
             None => bail!("missing block at {}", height),
             Some(blockhash) => blockhash,
         };
         let txids = self.daemon.get_block_txids(blockhash)?;
-        let txid:Txid = txids[*tx_pos];
+        let txid: Txid = txids[*tx_pos];
         if *merkle {
             match txids.iter().position(|current_txid| *current_txid == txid) {
                 None => bail!("missing txid {} in block {}", txid, blockhash),
@@ -420,8 +423,7 @@ impl Rpc {
                     }))
                 }
             }
-        }
-        else {
+        } else {
             Ok(json!({
                 "tx_id": txid,
             }))
@@ -609,7 +611,9 @@ impl Params {
             "blockchain.transaction.broadcast" => Params::TransactionBroadcast(convert(params)?),
             "blockchain.transaction.get" => Params::TransactionGet(convert(params)?),
             "blockchain.transaction.get_merkle" => Params::TransactionGetMerkle(convert(params)?),
-            "blockchain.transaction.id_from_pos" => Params::TransactionFromPosition(convert(params)?),
+            "blockchain.transaction.id_from_pos" => {
+                Params::TransactionFromPosition(convert(params)?)
+            }
             "mempool.get_fee_histogram" => Params::MempoolFeeHistogram,
             "server.banner" => Params::Banner,
             "server.donation_address" => Params::Donation,

--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -16,7 +16,7 @@ use crate::{
     cache::Cache,
     config::{Config, ELECTRS_VERSION},
     daemon::{self, extract_bitcoind_error, Daemon},
-    merkle::{Proof, self},
+    merkle::{Proof},
     metrics::{self, Histogram, Metrics},
     signals::Signal,
     status::ScriptHashStatus,
@@ -408,14 +408,14 @@ impl Rpc {
             Some(blockhash) => blockhash,
         };
         let txids = self.daemon.get_block_txids(blockhash)?;
-        let tx = txids[tx_pos];
+        let txid:Txid = txids[*tx_pos];
         if *merkle {
-            match txids.iter().position(|current_txid| *current_txid == *txid) {
+            match txids.iter().position(|current_txid| *current_txid == txid) {
                 None => bail!("missing txid {} in block {}", txid, blockhash),
                 Some(position) => {
                     let proof = Proof::create(&txids, position);
                     Ok(json!({
-                        "tx_id": tx,
+                        "tx_id": txid,
                         "merkle": proof.to_hex(),
                     }))
                 }
@@ -423,7 +423,7 @@ impl Rpc {
         }
         else {
             Ok(json!({
-                "tx_id": tx,
+                "tx_id": txid,
             }))
         }
     }

--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -411,6 +411,9 @@ impl Rpc {
             Some(blockhash) => blockhash,
         };
         let txids = self.daemon.get_block_txids(blockhash)?;
+        if *tx_pos >= txids.len() {
+            bail!("invalid tx_pos {} in block at height {}", tx_pos, height);
+        }
         let txid: Txid = txids[*tx_pos];
         if *merkle {
             match txids.iter().position(|current_txid| *current_txid == txid) {


### PR DESCRIPTION
Add [blockchain.transaction.id_from_pos](https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html#blockchain-transaction-id-from-pos) protocol method.

Fixes #834.