### PR TITLE
Implements`blockchain.scripthash.get_mempool` method for RPC

### DIFF
--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -19,7 +19,7 @@ use crate::{
     merkle::Proof,
     metrics::{self, Histogram, Metrics},
     signals::Signal,
-    status::{ScriptHashStatus},
+    status::ScriptHashStatus,
     tracker::Tracker,
     types::ScriptHash,
 };
@@ -296,7 +296,7 @@ impl Rpc {
             fee: u32,
         }
 
-        let mut mempool: Vec<TxnObject> = Vec::new(); 
+        let mut mempool: Vec<TxnObject> = Vec::new();
         let scripthash_status = match client.scripthashes.get(scripthash) {
             Some(status) => status,
             None => {
@@ -309,15 +309,23 @@ impl Rpc {
         };
 
         scripthash_status.mempool.iter().for_each(|tx_entry| {
-            mempool.push(TxnObject { height: -1, tx_hash: tx_entry.txid, fee: 123 });
+            mempool.push(TxnObject {
+                height: -1,
+                tx_hash: tx_entry.txid,
+                fee: 123,
+            });
         });
 
-        for (_,tx_entries) in &scripthash_status.confirmed {
+        for tx_entries in scripthash_status.confirmed.values() {
             tx_entries.iter().for_each(|tx_entry| {
-                mempool.push(TxnObject { height: 0, tx_hash: tx_entry.txid, fee: 123 });
+                mempool.push(TxnObject {
+                    height: 0,
+                    tx_hash: tx_entry.txid,
+                    fee: 123,
+                });
             });
         }
-    
+
         Ok(json!(mempool))
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -128,8 +128,8 @@ pub struct ScriptHashStatus {
     tip: BlockHash,         // used for skipping confirmed entries' sync
     pub confirmed: HashMap<BlockHash, Vec<TxEntry>>, // confirmed entries, partitioned per block (may contain stale blocks)
     pub mempool: Vec<TxEntry>,                       // unconfirmed entries
-    history: Vec<HistoryEntry>,                  // computed from confirmed and mempool entries
-    statushash: Option<StatusHash>,              // computed from history
+    history: Vec<HistoryEntry>,                      // computed from confirmed and mempool entries
+    statushash: Option<StatusHash>,                  // computed from history
 }
 
 /// Specific scripthash balance

--- a/src/status.rs
+++ b/src/status.rs
@@ -19,8 +19,8 @@ use crate::{
 };
 
 /// Given a scripthash, store relevant inputs and outputs of a specific transaction
-struct TxEntry {
-    txid: Txid,
+pub struct TxEntry {
+    pub txid: Txid,
     outputs: Vec<TxOutput>, // relevant funded outputs and their amounts
     spent: Vec<OutPoint>,   // relevant spent outpoints
 }
@@ -126,8 +126,8 @@ impl HistoryEntry {
 pub struct ScriptHashStatus {
     scripthash: ScriptHash, // specific scripthash to be queried
     tip: BlockHash,         // used for skipping confirmed entries' sync
-    confirmed: HashMap<BlockHash, Vec<TxEntry>>, // confirmed entries, partitioned per block (may contain stale blocks)
-    mempool: Vec<TxEntry>,                       // unconfirmed entries
+    pub confirmed: HashMap<BlockHash, Vec<TxEntry>>, // confirmed entries, partitioned per block (may contain stale blocks)
+    pub mempool: Vec<TxEntry>,                       // unconfirmed entries
     history: Vec<HistoryEntry>,                  // computed from confirmed and mempool entries
     statushash: Option<StatusHash>,              // computed from history
 }


### PR DESCRIPTION
Fixes #839 
Implements the `blockchain.scripthash.get_mempool` method with reference to [here](https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-mempool)