### PR TITLE
Fix typo in config_specification.toml

### DIFF
--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -73,7 +73,7 @@ doc = "Bitcoin daemon p2p 'addr:port' to connect (default: 127.0.0.1:8333 for ma
 [[param]]
 name = "monitoring_addr"
 type = "crate::config::ResolvAddr"
-doc = "Prometheus monitoring 'addr:port' to listen on (default: 127.0.0.1:4224 for mainnet, 127.0.0.1:14224 for testnet, 127.0.0.1:24224 for regtest and 127.0.0.1:34224 for regtest)"
+doc = "Prometheus monitoring 'addr:port' to listen on (default: 127.0.0.1:4224 for mainnet, 127.0.0.1:14224 for testnet, 127.0.0.1:24224 for regtest and 127.0.0.1:34224 for signet)"
 
 [[param]]
 name = "wait_duration_secs"


### PR DESCRIPTION
Just a simple typo fix I came across while playing around with custom signet.

This typo shows up when calling `electrs --help` with the following error:

```
        --monitoring-addr         Prometheus monitoring 'addr:port' to listen on
                                  (default: 127.0.0.1:4224 for mainnet,
                                  127.0.0.1:14224 for testnet, 127.0.0.1:24224
                                  for regtest and 127.0.0.1:34224 for regtest)
```

It should have read `127.0.0.1:34224 for signet`.