### PR TITLE
Dockerfile: re-add curl for the second time, so it can be used for docker health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM debian:bookworm-slim as base
 RUN apt-get update -qqy
-RUN apt-get install -qqy librocksdb-dev
+RUN apt-get install -qqy librocksdb-dev curl
 
 ### Electrum Rust Server ###
 FROM base as electrs-build


### PR DESCRIPTION
It has been silently removed via dd21df19db7326b9ce3aaa2641f08d222732d337, introducing a regression.