### PR TITLE
Bitcoin slices integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
+name = "bitcoin-test-data"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c188654f9dce3bc6ce1bfa9c49777ad514bcad37e421b5f53e9d0ee10603f34"
+
+[[package]]
 name = "bitcoin_hashes"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,16 @@ checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
  "serde",
+]
+
+[[package]]
+name = "bitcoin_slices"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c03df40e62cef35166f0ddf8268917142f38de88955fcc0721b28820160704"
+dependencies = [
+ "bitcoin",
+ "sha2",
 ]
 
 [[package]]
@@ -128,6 +144,15 @@ name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "byteorder"
@@ -226,6 +251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +303,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +355,8 @@ version = "0.10.0"
 dependencies = [
  "anyhow",
  "bitcoin",
+ "bitcoin-test-data",
+ "bitcoin_slices",
  "bitcoincore-rpc",
  "configure_me",
  "configure_me_codegen",
@@ -397,6 +453,16 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -910,6 +976,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1125,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ spec = "internal/config_specification.toml"
 [dependencies]
 anyhow = "1.0"
 bitcoin = { version = "0.30.0", features = ["serde", "rand-std"] }
+bitcoin_slices = { version = "0.6", features =["bitcoin", "sha2"] }
 bitcoincore-rpc = "0.17.0"
 configure_me = "0.4"
 crossbeam-channel = "0.5"
@@ -50,5 +51,6 @@ features = ["zstd", "snappy"]
 configure_me_codegen = { version = "0.4.4", default-features = false }
 
 [dev-dependencies]
+bitcoin-test-data = "0.2.0"
 hex_lit = "0.1.1"
 tempfile = "3.5"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 
-use bitcoin::{Amount, Block, BlockHash, Transaction, Txid};
+use bitcoin::{Amount, BlockHash, Transaction, Txid};
 use bitcoincore_rpc::{json, jsonrpc, Auth, Client, RpcApi};
 use crossbeam_channel::Receiver;
 use parking_lot::Mutex;
@@ -16,6 +16,7 @@ use crate::{
     metrics::Metrics,
     p2p::Connection,
     signals::ExitFlag,
+    types::SerBlock,
 };
 
 enum PollResult {
@@ -231,7 +232,7 @@ impl Daemon {
     pub(crate) fn for_blocks<B, F>(&self, blockhashes: B, func: F) -> Result<()>
     where
         B: IntoIterator<Item = BlockHash>,
-        F: FnMut(BlockHash, Block),
+        F: FnMut(BlockHash, SerBlock),
     {
         self.p2p.lock().for_blocks(blockhashes, func)
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use bitcoin::consensus::{deserialize, serialize};
+use bitcoin::consensus::{deserialize, serialize, Decodable};
 use bitcoin::{Block, BlockHash, OutPoint, Txid};
 
 use crate::{
@@ -202,6 +202,8 @@ impl Index {
         daemon.for_blocks(blockhashes, |blockhash, block| {
             let height = heights.next().expect("unexpected block");
             self.stats.observe_duration("block", || {
+                let block =
+                    Block::consensus_decode(&mut &block[..]).expect("core returned invalid block");
                 index_single_block(blockhash, block, height, &mut batch);
             });
             self.stats.height.set("tip", height as f64);

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,7 @@ use bitcoin::{
     hashes::{hash_newtype, sha256, Hash},
     OutPoint, Script, Txid,
 };
+use bitcoin_slices::bsl;
 
 use crate::db;
 
@@ -43,6 +44,7 @@ const HEIGHT_SIZE: usize = 4;
 
 type HashPrefix = [u8; HASH_PREFIX_LEN];
 type Height = u32;
+pub(crate) type SerBlock = Vec<u8>;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub(crate) struct HashPrefixRow {
@@ -188,6 +190,10 @@ impl HeaderRow {
     pub(crate) fn from_db_row(row: &[u8]) -> Self {
         deserialize(row).expect("bad HeaderRow")
     }
+}
+
+pub(crate) fn bsl_txid(tx: &bsl::Transaction) -> Txid {
+    bitcoin::Txid::from_slice(tx.txid_sha2().as_slice()).expect("invalid txid")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is a proof of concept using bitcoin_slices since it seems a good fit.

Parsing a block with rust_bitcoin is expensive because of allocating all the needed data, since many times you are interested only in a subset of it, we can skip most of the work, for example, to find a transaction.

UPDATED: added visiting of inputs and outputs via bitcoin_slices since the idea seems interesting for the maintainer

Fixes #864.