### PR TITLE
Allow existing mempool sync on SIGINT

### DIFF
--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -65,7 +65,7 @@ impl Tracker {
     pub(crate) fn sync(&mut self, daemon: &Daemon, exit_flag: &ExitFlag) -> Result<bool> {
         let done = self.index.sync(daemon, exit_flag)?;
         if done && !self.ignore_mempool {
-            self.mempool.sync(daemon);
+            self.mempool.sync(daemon, exit_flag);
             // TODO: double check tip - and retry on diff
         }
         Ok(done)


### PR DESCRIPTION
Otherwise, electrs cannot be gracefully stopped during the first mempool sync (currently [having >100k transactions](https://mempool.space/)).