### PR TITLE
Avoid precompiled 'serde_derive' >=1.0.172

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,18 +880,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ parking_lot = "0.12"
 prometheus = { version = "0.13", optional = true }
 rayon = "1.7"
 serde = "1.0"
-serde_derive = "1.0"
+serde_derive = "1.0, <=1.0.171"  # avoid precompiled binaries (https://github.com/serde-rs/serde/issues/2538)
 serde_json = "1.0"
 signal-hook = "0.3"
 tiny_http = { version = "0.12", optional = true }


### PR DESCRIPTION
Following https://github.com/serde-rs/serde/issues/2538.