### PR TITLE
allow breaking inside for_blocks closures using ControlFlow

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10,6 +10,7 @@ use serde_json::{json, value::RawValue, Value};
 
 use std::fs::File;
 use std::io::Read;
+use std::ops::ControlFlow;
 use std::path::Path;
 
 use crate::{
@@ -275,10 +276,10 @@ impl Daemon {
         self.p2p.lock().get_new_headers(chain)
     }
 
-    pub(crate) fn for_blocks<B, F>(&self, blockhashes: B, func: F) -> Result<()>
+    pub(crate) fn for_blocks<B, F, R>(&self, blockhashes: B, func: F) -> Result<ControlFlow<R>>
     where
         B: IntoIterator<Item = BlockHash>,
-        F: FnMut(BlockHash, SerBlock),
+        F: FnMut(BlockHash, SerBlock) -> ControlFlow<R>,
     {
         self.p2p.lock().for_blocks(blockhashes, func)
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -216,6 +216,7 @@ impl Index {
                 index_single_block(blockhash, block, height, &mut batch);
             });
             self.stats.height.set("tip", height as f64);
+            ControlFlow::Continue::<()>(())
         })?;
         let heights: Vec<_> = heights.collect();
         assert!(


### PR DESCRIPTION
bitcoind will keep sending blocks even if `ControlFlow::Break(_)` if returned, so they have to be received to not interfere with future calls. blocks technically do not have to be parsed then, which happens now at the sender side of `blocks_recv`, but this makes more sense to optimize that together with using bitcoin_slices (#913 moves parsing of the block to the receiver side).

is it possible to send bitcoind some message to stop sending blocks? otherwise it would be possible to request a few at a time and stop when `ControlFlow::Break(_)` is returned to prevent having to receive (and bitcoind having to read from disk and send) many blocks.

i also rewrote `lookup_transaction` to use this method of breaking, which will save at least parsing unneeded blocks later (#913). the only change to this function right now is `for_blocks` will keep the state with the ControlFlow enum instead of `lookup_transaction` with Option

i also happened to need this when making a poc implementation for is_unused (#920)