### PR TITLE
Drop 'recursion_limit' definition

### DIFF
--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"]
-
 use anyhow::Result;
 
 fn main() -> Result<()> {


### PR DESCRIPTION
It's a leftover from https://github.com/rust-lang-deprecated/error-chain