### PR TITLE
Upgrade `bitcoin` dependency to 0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bech32"
-version = "0.9.1"
+version = "0.10.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
 name = "bindgen"
@@ -63,23 +63,27 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
+checksum = "5973a027b341b462105675962214dfe3c938ad9afd395d84b28602608bdcec7b"
 dependencies = [
  "bech32",
- "bitcoin-private",
+ "bitcoin-internals",
  "bitcoin_hashes",
+ "hex-conservative",
  "hex_lit",
  "secp256k1",
  "serde",
 ]
 
 [[package]]
-name = "bitcoin-private"
-version = "0.1.0"
+name = "bitcoin-internals"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-test-data"
@@ -89,19 +93,20 @@ checksum = "0c188654f9dce3bc6ce1bfa9c49777ad514bcad37e421b5f53e9d0ee10603f34"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-private",
+ "bitcoin-internals",
+ "hex-conservative",
  "serde",
 ]
 
 [[package]]
 name = "bitcoin_slices"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6bcb852d9bbd32230b600e2633cdd23d6dcdab3116ab53285dc45075b9ce51"
+checksum = "4b221249ba4685e0f737f0df2c7bb656d527fdd8ede83ac066c4c8ce95898f42"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",
@@ -110,11 +115,10 @@ dependencies = [
 
 [[package]]
 name = "bitcoincore-rpc"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6c0ee9354e3dac217db4cb1dd31941073a87fe53c86bcf3eb2b8bc97f00a08"
+checksum = "8eb70725a621848c83b3809913d5314c0d20ca84877d99dd909504b564edab00"
 dependencies = [
- "bitcoin-private",
  "bitcoincore-rpc-json",
  "jsonrpc",
  "log",
@@ -124,12 +128,11 @@ dependencies = [
 
 [[package]]
 name = "bitcoincore-rpc-json"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30ce6f40fb0a2e8d98522796219282504b7a4b14e2b4c26139a7bea6aec6586"
+checksum = "856ffbee2e492c23bca715d72ea34aae80d58400f2bda26a82015d6bc2ec3662"
 dependencies = [
  "bitcoin",
- "bitcoin-private",
  "serde",
  "serde_json",
 ]
@@ -493,6 +496,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 
 [[package]]
 name = "hex_lit"
@@ -923,9 +932,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secp256k1"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
 dependencies = [
  "bitcoin_hashes",
  "rand",
@@ -935,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+checksum = "09e67c467c38fd24bd5499dc9a18183b31575c12ee549197e3e20d57aa4fe3b7"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ spec = "internal/config_specification.toml"
 
 [dependencies]
 anyhow = "1.0"
-bitcoin = { version = "0.30.0", features = ["serde", "rand-std"] }
-bitcoin_slices = { version = "0.6", features =["bitcoin", "sha2"] }
-bitcoincore-rpc = "0.17.0"
+bitcoin = { version = "0.31.0", features = ["serde", "rand-std"] }
+bitcoin_slices = { version = "0.7", features = ["bitcoin", "sha2"] }
+bitcoincore-rpc = { version = "0.18" }
 configure_me = "0.4"
 crossbeam-channel = "0.5"
 dirs-next = "2.0"

--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -52,7 +52,7 @@ doc = "JSONRPC authentication cookie file (default: ~/.bitcoin/.cookie)"
 [[param]]
 name = "network"
 type = "crate::config::BitcoinNetwork"
-convert_into = "::bitcoin::network::constants::Network"
+convert_into = "::bitcoin::Network"
 doc = "Select Bitcoin network type ('bitcoin', 'testnet', 'regtest' or 'signet')"
 default = "Default::default()"
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -29,7 +29,7 @@ impl Cache {
     pub fn add_tx(&self, txid: Txid, f: impl FnOnce() -> Transaction) {
         self.txs.write().entry(txid).or_insert_with(|| {
             let tx = f();
-            self.txs_size.observe("serialized", tx.size() as f64);
+            self.txs_size.observe("serialized", tx.total_size() as f64);
             tx
         });
     }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
 
 use bitcoin::blockdata::block::Header as BlockHeader;
-use bitcoin::network::constants;
-use bitcoin::BlockHash;
+use bitcoin::{BlockHash, Network};
 
 /// A new header found, to be added to the chain at specific height
 pub(crate) struct NewHeader {
@@ -37,7 +36,7 @@ pub struct Chain {
 
 impl Chain {
     // create an empty chain
-    pub fn new(network: constants::Network) -> Self {
+    pub fn new(network: Network) -> Self {
         let genesis = bitcoin::blockdata::constants::genesis_block(network);
         let genesis_hash = genesis.block_hash();
         Self {
@@ -148,7 +147,7 @@ mod tests {
     use super::{Chain, NewHeader};
     use bitcoin::blockdata::block::Header as BlockHeader;
     use bitcoin::consensus::deserialize;
-    use bitcoin::network::constants::Network::Regtest;
+    use bitcoin::Network::Regtest;
     use hex_lit::hex;
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
-use bitcoin::network::constants::{Magic, Network};
+use bitcoin::p2p::Magic;
+use bitcoin::Network;
 use bitcoincore_rpc::Auth;
 use dirs_next::home_dir;
 

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -7,12 +7,11 @@ use bitcoin::{
         Decodable,
     },
     hashes::Hash,
-    network::{
-        address,
-        constants::{self, Magic},
+    p2p::{
+        self, address,
         message::{self, CommandString, NetworkMessage},
         message_blockdata::{GetHeadersMessage, Inventory},
-        message_network,
+        message_network, Magic,
     },
     secp256k1::{self, rand::Rng},
     Block, BlockHash, Network,
@@ -199,10 +198,7 @@ impl Connection {
             };
             send_duration.observe_duration("send", || {
                 trace!("send: {:?}", msg);
-                let raw_msg = message::RawNetworkMessage {
-                    magic,
-                    payload: msg,
-                };
+                let raw_msg = message::RawNetworkMessage::new(magic, msg);
                 buffer.clear();
                 raw_msg
                     .consensus_encode(&mut buffer)
@@ -331,10 +327,10 @@ fn build_version_message() -> NetworkMessage {
         .expect("Time error")
         .as_secs() as i64;
 
-    let services = constants::ServiceFlags::NONE;
+    let services = p2p::ServiceFlags::NONE;
 
     NetworkMessage::Version(message_network::VersionMessage {
-        version: constants::PROTOCOL_VERSION,
+        version: p2p::PROTOCOL_VERSION,
         services,
         timestamp,
         receiver: address::Address::new(&addr, services),

--- a/src/status.rs
+++ b/src/status.rs
@@ -467,7 +467,7 @@ fn filter_outputs(tx: &Transaction, scripthash: ScriptHash) -> Vec<TxOutput> {
             if ScriptHash::new(&txo.script_pubkey) == scripthash {
                 Some(TxOutput {
                     index: vout,
-                    value: Amount::from_sat(txo.value),
+                    value: txo.value,
                 })
             } else {
                 None


### PR DESCRIPTION
This is not a merge candidate.

Upgrade dependencies required to use the recently released `rust-bitcoin v0.31.0-rc1` release.

Done while trying to upgrade `bdk` to use the bitcoin RC release.