### PR TITLE
Document cleanse of build artifacts

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -5,8 +5,8 @@
 
 ```bash
 $ sudo apt update
-$ sudo apt install -y clang cmake build-essential git cargo 
-$ git clone https://github.com/romanz/electrs 
+$ sudo apt install -y clang cmake build-essential git cargo
+$ git clone https://github.com/romanz/electrs
 $ cd electrs
 $ cargo build --locked --release
 $ ./target/release/electrs --version  # should print the latest version
@@ -205,6 +205,11 @@ $ RUSTFLAGS="-C link-args=-latomic" cargo build --locked --release
 Relevant issues: [#134](https://github.com/romanz/electrs/issues/134) and [#391](https://github.com/romanz/electrs/issues/391).
 
 #### Dynamic linking
+
+Note that if you have previously done a static linking build, it is recommended to clean the build artifacts to avoid build errors (e.g. https://github.com/romanz/electrs/issues/1001):
+```
+$ cargo clean
+```
 
 ```
 $ ROCKSDB_INCLUDE_DIR=/usr/include ROCKSDB_LIB_DIR=/usr/lib cargo build --locked --release


### PR DESCRIPTION
Fixes: https://github.com/romanz/electrs/issues/1001

---

Do you prefer for it to be documented in the dynamic linking section or move it to be more globally after this line 
https://github.com/romanz/electrs/blob/576b5b2bb642df786e17d2a58429d32fae482841/doc/install.md?plain=1#L185
?