### PR TITLE
fix deprecation and clippy warnings

### DIFF
--- a/examples/tx_collisions.rs
+++ b/examples/tx_collisions.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use electrs_rocksdb::{ColumnFamilyDescriptor, IteratorMode, Options, DB};
 
 fn main() -> Result<()> {
-    let path = std::env::args().skip(1).next().context("missing DB path")?;
+    let path = std::env::args().nth(1).context("missing DB path")?;
     let cf_names = DB::list_cf(&Options::default(), &path)?;
     let cfs: Vec<_> = cf_names
         .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,7 +183,7 @@ fn default_daemon_dir() -> PathBuf {
 fn default_config_files() -> Vec<OsString> {
     let mut files = vec![OsString::from("electrs.toml")]; // cwd
     if let Some(mut path) = home_dir() {
-        path.extend(&[".electrs", "config.toml"]);
+        path.extend([".electrs", "config.toml"]);
         files.push(OsString::from(path)) // home directory
     }
     files.push(OsString::from("/etc/electrs/config.toml")); // system-wide

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -344,7 +344,7 @@ impl Serialize for FeeHistogram {
         let mut seq = serializer.serialize_seq(Some(self.vsize.len()))?;
         // https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html#mempool-get-fee-histogram
         let fee_rates =
-            (0..FeeHistogram::BINS).map(|i| std::u64::MAX.checked_shr(i as u32).unwrap_or(0));
+            (0..FeeHistogram::BINS).map(|i| u64::MAX.checked_shr(i as u32).unwrap_or(0));
         fee_rates
             .zip(self.vsize.iter().copied())
             .skip_while(|(_fee_rate, vsize)| *vsize == 0)

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -108,6 +108,6 @@ mod tests {
             .join(block_hash_hex);
         let data = std::fs::read(path).unwrap();
         let block: Block = deserialize(&data).unwrap();
-        block.txdata.iter().map(|tx| tx.txid()).collect()
+        block.txdata.iter().map(|tx| tx.compute_txid()).collect()
     }
 }


### PR DESCRIPTION
`Transaction::txid()` was deprecated in the update to 0.32 (just renamed)