### PR TITLE
Save on allocations by using fixed size types for database rows

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -57,11 +57,11 @@ impl Chain {
     }
 
     /// Load the chain from a collection of headers, up to the given tip
-    pub(crate) fn load(&mut self, headers: Vec<BlockHeader>, tip: BlockHash) {
+    pub(crate) fn load(&mut self, headers: impl Iterator<Item = BlockHeader>, tip: BlockHash) {
         let genesis_hash = self.headers[0].0;
 
         let header_map: HashMap<BlockHash, BlockHeader> =
-            headers.into_iter().map(|h| (h.block_hash(), h)).collect();
+            headers.map(|h| (h.block_hash(), h)).collect();
         let mut blockhash = tip;
         let mut new_headers: Vec<&BlockHeader> = Vec::with_capacity(header_map.len());
         while blockhash != genesis_hash {
@@ -202,7 +202,10 @@ hex!("000000200030d7f9c11ef35b89a0eefb9a5e449909339b5e7854d99804ea8d6a49bf900a03
 
         // test loading from a list of headers and tip
         let mut regtest = Chain::new(Regtest);
-        regtest.load(headers.clone(), headers.last().unwrap().block_hash());
+        regtest.load(
+            headers.iter().copied(),
+            headers.last().unwrap().block_hash(),
+        );
         assert_eq!(regtest.height(), headers.len());
 
         // test getters
@@ -239,7 +242,10 @@ hex!("000000200030d7f9c11ef35b89a0eefb9a5e449909339b5e7854d99804ea8d6a49bf900a03
 
         // test reorg
         let mut regtest = Chain::new(Regtest);
-        regtest.load(headers.clone(), headers.last().unwrap().block_hash());
+        regtest.load(
+            headers.iter().copied(),
+            headers.last().unwrap().block_hash(),
+        );
         let height = regtest.height();
 
         let new_header: BlockHeader = deserialize(&hex!("000000200030d7f9c11ef35b89a0eefb9a5e449909339b5e7854d99804ea8d6a49bf900a0304d2e55fe0b6415949cff9bca0f88c0717884a5e5797509f89f856af93624a7a6bcc60ffff7f2000000000")).unwrap();

--- a/src/db.rs
+++ b/src/db.rs
@@ -330,7 +330,7 @@ impl DBStore {
         for key in &batch.header_rows {
             db_batch.put_cf(self.headers_cf(), key, b"");
         }
-        db_batch.put_cf(self.headers_cf(), TIP_KEY, &batch.tip_row);
+        db_batch.put_cf(self.headers_cf(), TIP_KEY, batch.tip_row);
 
         let mut opts = rocksdb::WriteOptions::new();
         let bulk_import = self.bulk_import.load(Ordering::Relaxed);

--- a/src/db.rs
+++ b/src/db.rs
@@ -392,7 +392,10 @@ impl<'a, const N: usize> Iterator for DBIterator<'a, N> {
         while !self.done {
             let key = match self.raw.key() {
                 Some(key) => key,
-                None => break, // end of scan
+                None => {
+                    self.raw.status().expect("DB scan failed");
+                    break; // end of scan
+                }
             };
             let prefix_match = match self.prefix {
                 Some(key_prefix) => key.starts_with(&key_prefix),
@@ -408,7 +411,6 @@ impl<'a, const N: usize> Iterator for DBIterator<'a, N> {
                 None => continue, // skip keys with size != N
             }
         }
-        self.raw.status().expect("DB scan failed");
         self.done = true;
         None
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -254,7 +254,7 @@ impl DBStore {
         })
     }
 
-    pub(crate) fn read_headers(&self) -> impl Iterator<Item = [u8; HEADER_ROW_SIZE]> + '_ {
+    pub(crate) fn iter_headers(&self) -> impl Iterator<Item = [u8; HEADER_ROW_SIZE]> + '_ {
         let mut opts = rocksdb::ReadOptions::default();
         opts.fill_cache(false);
         self.db

--- a/src/db.rs
+++ b/src/db.rs
@@ -262,7 +262,11 @@ impl DBStore {
                 None
             } else if let Some((key, _)) = raw_iter.item() {
                 let ret = if filter_fn(key) {
-                    Some(key.try_into().unwrap())
+                    Some(
+                        key.try_into()
+                            .with_context(|| format!("expected {N} bytes, got {}", key.len()))
+                            .expect("database key has wrong length"),
+                    )
                 } else {
                     None
                 };

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
-use bitcoin::consensus::{deserialize, serialize, Decodable};
+use bitcoin::consensus::{deserialize, Decodable, Encodable};
+use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, OutPoint, Txid};
 use bitcoin_slices::{bsl, Visit, Visitor};
 use std::ops::ControlFlow;
@@ -7,7 +8,7 @@ use std::ops::ControlFlow;
 use crate::{
     chain::{Chain, NewHeader},
     daemon::Daemon,
-    db::{DBStore, Row, WriteBatch},
+    db::{DBStore, WriteBatch},
     metrics::{self, Gauge, Histogram, Metrics},
     signals::ExitFlag,
     types::{
@@ -48,8 +49,8 @@ impl Stats {
         self.update_duration.observe_duration(label, f)
     }
 
-    fn observe_size(&self, label: &str, rows: &[Row]) {
-        self.update_size.observe(label, db_rows_size(rows) as f64);
+    fn observe_size<const N: usize>(&self, label: &str, rows: &[[u8; N]]) {
+        self.update_size.observe(label, (rows.len() * N) as f64);
     }
 
     fn observe_batch(&self, batch: &WriteBatch) {
@@ -102,8 +103,7 @@ impl Index {
             let tip = deserialize(&row).expect("invalid tip");
             let headers = store
                 .read_headers()
-                .into_iter()
-                .map(|row| HeaderRow::from_db_row(&row).header)
+                .map(|row| HeaderRow::from_db_row(row).header)
                 .collect();
             chain.load(headers, tip);
             chain.drop_last_headers(reindex_last_blocks);
@@ -141,7 +141,7 @@ impl Index {
     pub(crate) fn filter_by_txid(&self, txid: Txid) -> impl Iterator<Item = BlockHash> + '_ {
         self.store
             .iter_txid(TxidRow::scan_prefix(txid))
-            .map(|row| HashPrefixRow::from_db_row(&row).height())
+            .map(|row| HashPrefixRow::from_db_row(row).height())
             .filter_map(move |height| self.chain.get_block_hash(height))
     }
 
@@ -151,7 +151,7 @@ impl Index {
     ) -> impl Iterator<Item = BlockHash> + '_ {
         self.store
             .iter_funding(ScriptHashRow::scan_prefix(scripthash))
-            .map(|row| HashPrefixRow::from_db_row(&row).height())
+            .map(|row| HashPrefixRow::from_db_row(row).height())
             .filter_map(move |height| self.chain.get_block_hash(height))
     }
 
@@ -161,7 +161,7 @@ impl Index {
     ) -> impl Iterator<Item = BlockHash> + '_ {
         self.store
             .iter_spending(SpendingPrefixRow::scan_prefix(outpoint))
-            .map(|row| HashPrefixRow::from_db_row(&row).height())
+            .map(|row| HashPrefixRow::from_db_row(row).height())
             .filter_map(move |height| self.chain.get_block_hash(height))
     }
 
@@ -236,10 +236,6 @@ impl Index {
     }
 }
 
-fn db_rows_size(rows: &[Row]) -> usize {
-    rows.iter().map(|key| key.len()).sum()
-}
-
 fn index_single_block(
     block_hash: BlockHash,
     block: SerBlock,
@@ -292,5 +288,9 @@ fn index_single_block(
 
     let mut index_block = IndexBlockVisitor { batch, height };
     bsl::Block::visit(&block, &mut index_block).expect("core returned invalid block");
-    batch.tip_row = serialize(&block_hash).into_boxed_slice();
+
+    let len = block_hash
+        .consensus_encode(&mut (&mut batch.tip_row as &mut [u8]))
+        .expect("in-memory writers don't error");
+    debug_assert_eq!(len, BlockHash::LEN);
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -102,9 +102,8 @@ impl Index {
         if let Some(row) = store.get_tip() {
             let tip = deserialize(&row).expect("invalid tip");
             let headers = store
-                .read_headers()
-                .map(|row| HeaderRow::from_db_row(row).header)
-                .collect();
+                .iter_headers()
+                .map(|row| HeaderRow::from_db_row(row).header);
             chain.load(headers, tip);
             chain.drop_last_headers(reindex_last_blocks);
         };

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,8 +10,6 @@ use bitcoin::{
 };
 use bitcoin_slices::bsl;
 
-use crate::db;
-
 macro_rules! impl_consensus_encoding {
     ($thing:ident, $($field:ident),+) => (
         impl Encodable for $thing {
@@ -39,7 +37,7 @@ macro_rules! impl_consensus_encoding {
     );
 }
 
-const HASH_PREFIX_LEN: usize = 8;
+pub const HASH_PREFIX_LEN: usize = 8;
 const HEIGHT_SIZE: usize = 4;
 
 type HashPrefix = [u8; HASH_PREFIX_LEN];
@@ -52,20 +50,20 @@ pub(crate) struct HashPrefixRow {
     height: Height, // transaction confirmed height
 }
 
-const HASH_PREFIX_ROW_SIZE: usize = HASH_PREFIX_LEN + HEIGHT_SIZE;
+pub const HASH_PREFIX_ROW_SIZE: usize = HASH_PREFIX_LEN + HEIGHT_SIZE;
 
 impl HashPrefixRow {
-    pub(crate) fn to_db_row(&self) -> db::Row {
-        let mut vec = Vec::with_capacity(HASH_PREFIX_ROW_SIZE);
+    pub(crate) fn to_db_row(&self) -> [u8; HASH_PREFIX_ROW_SIZE] {
+        let mut row = [0; HASH_PREFIX_ROW_SIZE];
         let len = self
-            .consensus_encode(&mut vec)
+            .consensus_encode(&mut (&mut row as &mut [u8]))
             .expect("in-memory writers don't error");
         debug_assert_eq!(len, HASH_PREFIX_ROW_SIZE);
-        vec.into_boxed_slice()
+        row
     }
 
-    pub(crate) fn from_db_row(row: &[u8]) -> Self {
-        deserialize(row).expect("bad HashPrefixRow")
+    pub(crate) fn from_db_row(row: [u8; HASH_PREFIX_ROW_SIZE]) -> Self {
+        deserialize(&row).expect("bad HashPrefixRow")
     }
 
     pub fn height(&self) -> usize {
@@ -96,8 +94,8 @@ impl ScriptHash {
 pub(crate) struct ScriptHashRow;
 
 impl ScriptHashRow {
-    pub(crate) fn scan_prefix(scripthash: ScriptHash) -> Box<[u8]> {
-        scripthash.0[..HASH_PREFIX_LEN].to_vec().into_boxed_slice()
+    pub(crate) fn scan_prefix(scripthash: ScriptHash) -> [u8; HASH_PREFIX_LEN] {
+        scripthash.0[..HASH_PREFIX_LEN].try_into().unwrap()
     }
 
     pub(crate) fn row(scripthash: ScriptHash, height: usize) -> HashPrefixRow {
@@ -127,8 +125,8 @@ fn spending_prefix(prev: OutPoint) -> HashPrefix {
 pub(crate) struct SpendingPrefixRow;
 
 impl SpendingPrefixRow {
-    pub(crate) fn scan_prefix(outpoint: OutPoint) -> Box<[u8]> {
-        Box::new(spending_prefix(outpoint))
+    pub(crate) fn scan_prefix(outpoint: OutPoint) -> [u8; HASH_PREFIX_LEN] {
+        spending_prefix(outpoint)
     }
 
     pub(crate) fn row(outpoint: OutPoint, height: usize) -> HashPrefixRow {
@@ -150,8 +148,8 @@ fn txid_prefix(txid: &Txid) -> HashPrefix {
 pub(crate) struct TxidRow;
 
 impl TxidRow {
-    pub(crate) fn scan_prefix(txid: Txid) -> Box<[u8]> {
-        Box::new(txid_prefix(&txid))
+    pub(crate) fn scan_prefix(txid: Txid) -> [u8; HASH_PREFIX_LEN] {
+        txid_prefix(&txid)
     }
 
     pub(crate) fn row(txid: Txid, height: usize) -> HashPrefixRow {
@@ -169,7 +167,7 @@ pub(crate) struct HeaderRow {
     pub(crate) header: BlockHeader,
 }
 
-const HEADER_ROW_SIZE: usize = 80;
+pub const HEADER_ROW_SIZE: usize = 80;
 
 impl_consensus_encoding!(HeaderRow, header);
 
@@ -178,17 +176,17 @@ impl HeaderRow {
         Self { header }
     }
 
-    pub(crate) fn to_db_row(&self) -> db::Row {
-        let mut vec = Vec::with_capacity(HEADER_ROW_SIZE);
+    pub(crate) fn to_db_row(&self) -> [u8; HEADER_ROW_SIZE] {
+        let mut row = [0; HEADER_ROW_SIZE];
         let len = self
-            .consensus_encode(&mut vec)
+            .consensus_encode(&mut (&mut row as &mut [u8]))
             .expect("in-memory writers don't error");
         debug_assert_eq!(len, HEADER_ROW_SIZE);
-        vec.into_boxed_slice()
+        row
     }
 
-    pub(crate) fn from_db_row(row: &[u8]) -> Self {
-        deserialize(row).expect("bad HeaderRow")
+    pub(crate) fn from_db_row(row: [u8; HEADER_ROW_SIZE]) -> Self {
+        deserialize(&row).expect("bad HeaderRow")
     }
 }
 
@@ -219,8 +217,8 @@ mod tests {
         let scripthash: ScriptHash = from_str(hex).unwrap();
         let row1 = ScriptHashRow::row(scripthash, 123456);
         let db_row = row1.to_db_row();
-        assert_eq!(&*db_row, &hex!("a384491d38929fcc40e20100"));
-        let row2 = HashPrefixRow::from_db_row(&db_row);
+        assert_eq!(db_row, hex!("a384491d38929fcc40e20100"));
+        let row2 = HashPrefixRow::from_db_row(db_row);
         assert_eq!(row1, row2);
     }
 
@@ -247,8 +245,8 @@ mod tests {
         let row1 = TxidRow::row(txid, 91812);
         let row2 = TxidRow::row(txid, 91842);
 
-        assert_eq!(&*row1.to_db_row(), &hex!("9985d82954e10f22a4660100"));
-        assert_eq!(&*row2.to_db_row(), &hex!("9985d82954e10f22c2660100"));
+        assert_eq!(row1.to_db_row(), hex!("9985d82954e10f22a4660100"));
+        assert_eq!(row2.to_db_row(), hex!("9985d82954e10f22c2660100"));
     }
 
     #[test]
@@ -261,8 +259,8 @@ mod tests {
         let row2 = TxidRow::row(txid, 91880);
 
         // low-endian encoding => rows should be sorted according to block height
-        assert_eq!(&*row1.to_db_row(), &hex!("68b45f58b674e94e4a660100"));
-        assert_eq!(&*row2.to_db_row(), &hex!("68b45f58b674e94ee8660100"));
+        assert_eq!(row1.to_db_row(), hex!("68b45f58b674e94e4a660100"));
+        assert_eq!(row2.to_db_row(), hex!("68b45f58b674e94ee8660100"));
     }
 
     #[test]


### PR DESCRIPTION
In the WriteBatch struct, I changed the `Vec<Box<[u8]>>` fields to `Vec<[u8, N]>`, which saves on memory allocations when indexing blocks and putting the results of that in the db, before this pr that adds up to 1 per unique output address per block (funding), 1 per spent utxo per block (spending) and 1 per transaction (txid) (and a bit more for tip_row and header_rows).

~When retrieving from the db currently `Box`es are still used, but this can be fixed by using rocksdb's raw iterators. (The optimizer might be able to even remove the `Box`es now that they are directly dropped, but as with almost all optimizations, they are not guaranteed).~
I also managed to fix this, 800000+ less `Box`es are now made when retrieving the headers on startup, and a lot too on electrum protocol requests (i think the amount here depends on the amount of blocks the address is used in, for history and balance at least)

And when loading headers, the iterator is not `.collect().into_iter()`'ed anymore (found that 2 times, so another 2 intermediate allocations saved).


I was experimenting with redb a bit, redb uses fixed size types, unlike rocksdb that only allows `&[u8]`, this change would also make it easier to use redb as db with electrs in the future, I plan on making a pr for adding redb if I get it to work.