### PR TITLE
WIP: try other kv stores to possibly replace RocksDB

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest]
         build-args:
           [
-            --locked --no-default-features,
+            --locked --no-default-features --features rocksdb,
             --locked
           ]
         include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "rayon",
+ "redb",
  "rust-rocksdb",
  "serde",
  "serde_derive",
@@ -860,6 +861,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,9 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -335,6 +338,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +404,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "doxygen-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
+dependencies = [
+ "phf",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +444,7 @@ dependencies = [
  "ctrlc",
  "dirs-next",
  "env_logger",
+ "heed",
  "hex_lit",
  "log",
  "parking_lot 0.12.3",
@@ -468,6 +501,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs2"
@@ -528,6 +570,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "heed"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a56c94661ddfb51aa9cdfbf102cfcc340aa69267f95ebccc4af08d7c530d393"
+dependencies = [
+ "bitflags 2.9.1",
+ "byteorder",
+ "heed-traits",
+ "heed-types",
+ "libc",
+ "lmdb-master-sys",
+ "once_cell",
+ "page_size",
+ "synchronoise",
+ "url",
+]
+
+[[package]]
+name = "heed-traits"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+
+[[package]]
+name = "heed-types"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
+dependencies = [
+ "byteorder",
+ "heed-traits",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +641,113 @@ name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "instant"
@@ -675,6 +858,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "lmdb-master-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864808e0b19fb6dd3b70ba94ee671b82fce17554cf80aeb0a155c65bb08027df"
+dependencies = [
+ "cc",
+ "doxygen-rs",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +941,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,10 +1014,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bddc33f680b79eaf1e2e56da792c3c2236f86985bbc3a886e8ddee17ae4d3a4"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1163,6 +1430,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "sled"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1458,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1472,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synchronoise"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
+dependencies = [
+ "crossbeam-queue",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1250,6 +1549,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1584,24 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vcpkg"
@@ -1432,6 +1759,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1802,60 @@ name = "zerocopy-derive"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -174,6 +174,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -186,6 +192,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bzip2-sys"
@@ -283,6 +295,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -393,7 +414,7 @@ dependencies = [
  "env_logger",
  "hex_lit",
  "log",
- "parking_lot",
+ "parking_lot 0.12.3",
  "prometheus",
  "rayon",
  "redb",
@@ -402,6 +423,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "signal-hook",
+ "sled",
  "tempfile",
  "tiny_http",
 ]
@@ -446,6 +468,25 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "generic-array"
@@ -526,6 +567,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,7 +647,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "libc",
 ]
 
@@ -669,7 +719,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "libc",
 ]
@@ -692,12 +742,37 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -708,7 +783,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.12",
  "smallvec",
  "windows-targets",
 ]
@@ -758,7 +833,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "hex",
  "lazy_static",
  "procfs-core",
@@ -771,7 +846,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "hex",
 ]
 
@@ -786,7 +861,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "parking_lot",
+ "parking_lot 0.12.3",
  "procfs",
  "protobuf",
  "thiserror",
@@ -874,11 +949,20 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -958,7 +1042,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -971,7 +1055,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -1076,6 +1160,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -1328,7 +1428,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn",
 ]
@@ -203,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteview"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6236364b88b9b6d0bc181ba374cf1ab55ba3ef97a1cb6f8cddad48a273767fb5"
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +269,12 @@ dependencies = [
  "glob",
  "libc",
 ]
+
+[[package]]
+name = "compare"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
 name = "configure_me"
@@ -347,6 +359,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +392,20 @@ checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
 dependencies = [
  "nix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -415,6 +451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "double-ended-peekable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0d05e1c0dbad51b52c38bda7adceef61b9efc2baf04acfe8726a8c4630a6f57"
+
+[[package]]
 name = "doxygen-rs"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +486,7 @@ dependencies = [
  "ctrlc",
  "dirs-next",
  "env_logger",
+ "fjall",
  "heed",
  "hex_lit",
  "log",
@@ -462,6 +505,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +528,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -489,6 +550,23 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fjall"
+version = "2.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25ad44cd4360a0448a9b5a0a6f1c7a621101cca4578706d43c9a821418aebc"
+dependencies = [
+ "byteorder",
+ "byteview",
+ "dashmap",
+ "log",
+ "lsm-tree",
+ "path-absolutize",
+ "std-semaphore",
+ "tempfile",
+ "xxhash-rust",
+]
 
 [[package]]
 name = "fmt2io"
@@ -568,6 +646,24 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "guardian"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heed"
@@ -759,6 +855,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "interval-heap"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11274e5e8e89b8607cfedc2910b6626e998779b48a019151c7604d0adcb86ac6"
+dependencies = [
+ "compare",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +996,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lsm-tree"
+version = "2.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab73c02eadb3dc12c0024e5b61d6284e6d59064e67e74fbad77856caa56f62c7"
+dependencies = [
+ "byteorder",
+ "crossbeam-skiplist",
+ "double-ended-peekable",
+ "enum_dispatch",
+ "guardian",
+ "interval-heap",
+ "log",
+ "lz4_flex",
+ "path-absolutize",
+ "quick_cache",
+ "rustc-hash 2.1.1",
+ "self_cell",
+ "tempfile",
+ "value-log",
+ "varint-rs",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1147,24 @@ name = "parse_arg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bddc33f680b79eaf1e2e56da792c3c2236f86985bbc3a886e8ddee17ae4d3a4"
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1139,6 +1292,16 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "quick_cache"
+version = "0.6.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ad6644cb07b7f3488b9f3d2fde3b4c0a7fa367cafefb39dff93a659f76eb786"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "quote"
@@ -1304,6 +1467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1530,12 @@ checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
 
 [[package]]
 name = "serde"
@@ -1462,6 +1637,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "std-semaphore"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
 
 [[package]]
 name = "syn"
@@ -1602,6 +1783,29 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "value-log"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fc7c4ce161f049607ecea654dca3f2d727da5371ae85e2e4f14ce2b98ed67c"
+dependencies = [
+ "byteorder",
+ "byteview",
+ "interval-heap",
+ "log",
+ "path-absolutize",
+ "rustc-hash 2.1.1",
+ "tempfile",
+ "varint-rs",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "varint-rs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f54a172d0620933a27a4360d3db3e2ae0dd6cceae9730751a036bbf182c4b23"
 
 [[package]]
 name = "vcpkg"
@@ -1763,6 +1967,12 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,14 @@ rust-version = "1.85.0"
 build = "build.rs"
 
 [features]
-default = ["metrics", "rocksdb", "lmdb", "redb", "sled"]
+default = ["metrics", "rocksdb", "lmdb", "redb", "sled", "fjall"]
 metrics = ["prometheus", "tiny_http"]
 metrics_process = ["prometheus/process"]
 rocksdb = ["dep:rust-rocksdb"]
 lmdb = ["dep:heed"]
 redb = ["dep:redb"]
 sled = ["dep:sled"]
+fjall = ["dep:fjall"]
 
 [package.metadata.configure_me]
 spec = "internal/config_specification.toml"
@@ -45,6 +46,7 @@ tiny_http = { version = "0.12", optional = true }
 heed = { version = "0.22.0", default-features = false, optional = true }
 redb = { version = "2.6.0", optional = true }
 sled = { version = "0.34.7", optional = true }
+fjall = { version = "2.11.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "=3.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,11 @@ rust-version = "1.85.0"
 build = "build.rs"
 
 [features]
-default = ["metrics", "rocksdb", "redb", "sled"]
+default = ["metrics", "rocksdb", "lmdb", "redb", "sled"]
 metrics = ["prometheus", "tiny_http"]
 metrics_process = ["prometheus/process"]
 rocksdb = ["dep:rust-rocksdb"]
+lmdb = ["dep:heed"]
 redb = ["dep:redb"]
 sled = ["dep:sled"]
 
@@ -41,6 +42,7 @@ serde = "1.0.184"
 serde_derive = "1.0.184"
 serde_json = "1.0"
 tiny_http = { version = "0.12", optional = true }
+heed = { version = "0.22.0", default-features = false, optional = true }
 redb = { version = "2.6.0", optional = true }
 sled = { version = "0.34.7", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,12 @@ rust-version = "1.85.0"
 build = "build.rs"
 
 [features]
-default = ["metrics", "rocksdb", "redb"]
+default = ["metrics", "rocksdb", "redb", "sled"]
 metrics = ["prometheus", "tiny_http"]
 metrics_process = ["prometheus/process"]
 rocksdb = ["dep:rust-rocksdb"]
 redb = ["dep:redb"]
+sled = ["dep:sled"]
 
 [package.metadata.configure_me]
 spec = "internal/config_specification.toml"
@@ -41,6 +42,7 @@ serde_derive = "1.0.184"
 serde_json = "1.0"
 tiny_http = { version = "0.12", optional = true }
 redb = { version = "2.6.0", optional = true }
+sled = { version = "0.34.7", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "=3.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ rust-version = "1.85.0"
 build = "build.rs"
 
 [features]
-default = ["metrics"]
+default = ["metrics", "rocksdb", "redb"]
 metrics = ["prometheus", "tiny_http"]
 metrics_process = ["prometheus/process"]
+rocksdb = ["dep:rust-rocksdb"]
+redb = ["dep:redb"]
 
 [package.metadata.configure_me]
 spec = "internal/config_specification.toml"
@@ -38,6 +40,7 @@ serde = "1.0.184"
 serde_derive = "1.0.184"
 serde_json = "1.0"
 tiny_http = { version = "0.12", optional = true }
+redb = { version = "2.6.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "=3.4.2"
@@ -47,6 +50,7 @@ signal-hook = "0.3"
 
 [dependencies.rust-rocksdb]
 version = "0.36"
+optional = true
 
 default-features = false
 # ZSTD is used for data compression

--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -155,5 +155,5 @@ doc = "network magic for custom signet network in hex format, as found in Bitcoi
 [[param]]
 name = "database"
 type = "crate::config::DatabaseType"
-doc = "Select database type ('rocksdb', 'redb' or 'sled')"
+doc = "Select database type ('rocksdb', 'lmdb', 'redb' or 'sled')"
 default = "Default::default()"

--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -155,5 +155,5 @@ doc = "network magic for custom signet network in hex format, as found in Bitcoi
 [[param]]
 name = "database"
 type = "crate::config::DatabaseType"
-doc = "Select database type ('rocksdb', 'lmdb', 'redb' or 'sled')"
+doc = "Select database type ('rocksdb', 'lmdb', 'redb', 'sled' or 'fjall')"
 default = "Default::default()"

--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -155,5 +155,5 @@ doc = "network magic for custom signet network in hex format, as found in Bitcoi
 [[param]]
 name = "database"
 type = "crate::config::DatabaseType"
-doc = "Select database type ('rocksdb' or 'redb')"
+doc = "Select database type ('rocksdb', 'redb' or 'sled')"
 default = "Default::default()"

--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -151,3 +151,9 @@ doc = "Logging filters, overriding `RUST_LOG` environment variable (see https://
 name = "signet_magic"
 type = "String"
 doc = "network magic for custom signet network in hex format, as found in Bitcoin Core logs (signet only)"
+
+[[param]]
+name = "database"
+type = "crate::config::DatabaseType"
+doc = "Select database type ('rocksdb' or 'redb')"
+default = "Default::default()"

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,6 +126,7 @@ pub enum DatabaseType {
     #[default]
     RocksDB,
     ReDB,
+    Sled,
 }
 
 impl FromStr for DatabaseType {
@@ -135,6 +136,7 @@ impl FromStr for DatabaseType {
         Ok(match s {
             "rocksdb" => Self::RocksDB,
             "redb" => Self::ReDB,
+            "sled" => Self::Sled,
             _ => return Err(UnknownDatabaseTypeError(s.to_owned())),
         })
     }
@@ -142,7 +144,7 @@ impl FromStr for DatabaseType {
 
 impl ::configure_me::parse_arg::ParseArgFromStr for DatabaseType {
     fn describe_type<W: fmt::Write>(mut writer: W) -> fmt::Result {
-        write!(writer, "either 'rocksdb' or 'redb'")
+        write!(writer, "either 'rocksdb', 'redb' or 'sled'")
     }
 }
 
@@ -151,6 +153,7 @@ impl fmt::Display for DatabaseType {
         match self {
             Self::RocksDB => write!(f, "rocksdb"),
             Self::ReDB => write!(f, "redb"),
+            Self::Sled => write!(f, "sled"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,6 +129,7 @@ pub enum DatabaseType {
     LMDB,
     ReDB,
     Sled,
+    Fjall,
 }
 
 impl FromStr for DatabaseType {
@@ -140,6 +141,7 @@ impl FromStr for DatabaseType {
             "lmdb" => Self::LMDB,
             "redb" => Self::ReDB,
             "sled" => Self::Sled,
+            "fjall" => Self::Fjall,
             _ => return Err(UnknownDatabaseTypeError(s.to_owned())),
         })
     }
@@ -147,7 +149,10 @@ impl FromStr for DatabaseType {
 
 impl ::configure_me::parse_arg::ParseArgFromStr for DatabaseType {
     fn describe_type<W: fmt::Write>(mut writer: W) -> fmt::Result {
-        write!(writer, "either 'rocksdb', 'lmdb', 'redb' or 'sled'")
+        write!(
+            writer,
+            "either 'rocksdb', 'lmdb', 'redb', 'sled' or 'fjall'"
+        )
     }
 }
 
@@ -158,6 +163,7 @@ impl fmt::Display for DatabaseType {
             Self::LMDB => write!(f, "lmdb"),
             Self::ReDB => write!(f, "redb"),
             Self::Sled => write!(f, "sled"),
+            Self::Fjall => write!(f, "fjall"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -122,9 +122,11 @@ impl From<BitcoinNetwork> for Network {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[allow(clippy::upper_case_acronyms)] // LMDB
 pub enum DatabaseType {
     #[default]
     RocksDB,
+    LMDB,
     ReDB,
     Sled,
 }
@@ -135,6 +137,7 @@ impl FromStr for DatabaseType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
             "rocksdb" => Self::RocksDB,
+            "lmdb" => Self::LMDB,
             "redb" => Self::ReDB,
             "sled" => Self::Sled,
             _ => return Err(UnknownDatabaseTypeError(s.to_owned())),
@@ -144,7 +147,7 @@ impl FromStr for DatabaseType {
 
 impl ::configure_me::parse_arg::ParseArgFromStr for DatabaseType {
     fn describe_type<W: fmt::Write>(mut writer: W) -> fmt::Result {
-        write!(writer, "either 'rocksdb', 'redb' or 'sled'")
+        write!(writer, "either 'rocksdb', 'lmdb', 'redb' or 'sled'")
     }
 }
 
@@ -152,6 +155,7 @@ impl fmt::Display for DatabaseType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::RocksDB => write!(f, "rocksdb"),
+            Self::LMDB => write!(f, "lmdb"),
             Self::ReDB => write!(f, "redb"),
             Self::Sled => write!(f, "sled"),
         }

--- a/src/db/fjall.rs
+++ b/src/db/fjall.rs
@@ -1,0 +1,217 @@
+use super::{Database, WriteBatch};
+use crate::types::{HashPrefix, HASH_PREFIX_ROW_SIZE, HEADER_ROW_SIZE};
+use anyhow::{Context, Result};
+use fjall::{Keyspace, PartitionHandle, PersistMode, Slice};
+use std::fs::{create_dir_all, remove_file};
+use std::path::Path;
+
+const FORMAT_KEY: u8 = b'F';
+const TIP_KEY: u8 = b'T';
+
+const CURRENT_FORMAT: u64 = 0;
+
+pub struct RowKeyIter<const N: usize>(
+    // TODO remove this (third) Box
+    Box<dyn Iterator<Item = Result<(Slice, Slice), fjall::Error>>>,
+);
+
+impl<const N: usize> Iterator for RowKeyIter<N> {
+    type Item = [u8; N];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|v| (&*v.unwrap().0).try_into().unwrap())
+    }
+}
+
+pub struct DBStore {
+    keyspace: Keyspace,
+    config: PartitionHandle,
+    headers: PartitionHandle,
+    funding: PartitionHandle,
+    spending: PartitionHandle,
+    txid: PartitionHandle,
+}
+
+impl Database for DBStore {
+    fn open(
+        path: &Path,
+        log_dir: Option<&Path>,
+        auto_reindex: bool,
+        _db_parallelism: u8,
+    ) -> Result<Self> {
+        create_dir_all(path).expect("unable to create directories");
+
+        if log_dir.is_some() {
+            info!("ignoring log_dir parameter, it is currently unsupported with fjall");
+        }
+
+        let mut this = Self::open_internal(path)?;
+
+        let reindex_cause =
+            if let Some(v) = this.config_value(FORMAT_KEY).expect("fjall read error") {
+                let format = u64::from_be_bytes(v);
+                if format != CURRENT_FORMAT {
+                    Some(format!(
+                        "unsupported format {} != {}",
+                        format, CURRENT_FORMAT
+                    ))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+        if let Some(cause) = reindex_cause {
+            if !auto_reindex {
+                bail!("re-index required due to {}", cause);
+            }
+            warn!(
+                "Database needs to be re-indexed due to {}, going to delete {}",
+                cause,
+                path.display()
+            );
+            // close DB before deletion
+            drop(this);
+            remove_file(path).with_context(|| {
+                format!(
+                    "re-index required but the old database ({}) can not be deleted",
+                    path.display()
+                )
+            })?;
+            this = Self::open_internal(path)?;
+        }
+
+        this.set_config_value(FORMAT_KEY, CURRENT_FORMAT.to_be_bytes())
+            .expect("fjall write error");
+        Ok(this)
+    }
+
+    type HashPrefixRowIter<'a> = RowKeyIter<HASH_PREFIX_ROW_SIZE>;
+
+    fn iter_funding(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        Self::iter_table_hash_prefix(&self.funding, prefix)
+    }
+
+    fn iter_spending(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        Self::iter_table_hash_prefix(&self.spending, prefix)
+    }
+
+    fn iter_txid(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        Self::iter_table_hash_prefix(&self.txid, prefix)
+    }
+
+    type HeaderIter<'a> = RowKeyIter<HEADER_ROW_SIZE>;
+
+    fn iter_headers(&self) -> Self::HeaderIter<'_> {
+        RowKeyIter(Box::new(self.headers.iter()))
+    }
+
+    fn get_tip(&self) -> Option<Vec<u8>> {
+        self.config_value(TIP_KEY)
+            .expect("unable to get tip")
+            .map(|arr: [u8; 32]| arr.to_vec())
+    }
+
+    fn write(&self, batch: &WriteBatch) {
+        let mut txn = self.keyspace.batch();
+
+        for key in &batch.funding_rows {
+            txn.insert(&self.funding, key, []);
+        }
+
+        for key in &batch.spending_rows {
+            txn.insert(&self.spending, key, []);
+        }
+
+        for key in &batch.txid_rows {
+            txn.insert(&self.txid, key, []);
+        }
+
+        for key in &batch.header_rows {
+            txn.insert(&self.headers, key, []);
+        }
+
+        txn.insert(&self.config, [TIP_KEY], batch.tip_row);
+
+        txn.commit().expect("fjall write error");
+    }
+
+    fn flush(&self) {
+        self.keyspace
+            .persist(PersistMode::SyncAll)
+            .expect("failed to flush");
+    }
+
+    fn update_metrics(&self, gauge: &crate::metrics::Gauge) {
+        gauge.set("fjall.disk_space", self.keyspace.disk_space() as f64);
+        gauge.set(
+            "fjall.write_buffer_size",
+            self.keyspace.write_buffer_size() as f64,
+        );
+        gauge.set("fjall.journal_count", self.keyspace.journal_count() as f64);
+
+        for table in [
+            &self.config,
+            &self.headers,
+            &self.funding,
+            &self.spending,
+            &self.txid,
+        ] {
+            gauge.set(
+                &format!("fjall.table_disk_space:{}", table.name),
+                table.disk_space() as f64,
+            );
+        }
+    }
+}
+
+impl DBStore {
+    fn open_internal(path: &Path) -> Result<Self, fjall::Error> {
+        let keyspace = fjall::Config::new(path).open()?;
+
+        let config = keyspace.open_partition("config", Default::default())?;
+        let headers = keyspace.open_partition("headers", Default::default())?;
+        let funding = keyspace.open_partition("funding", Default::default())?;
+        let spending = keyspace.open_partition("spending", Default::default())?;
+        let txid = keyspace.open_partition("txid", Default::default())?;
+
+        Ok(Self {
+            keyspace,
+            config,
+            headers,
+            funding,
+            spending,
+            txid,
+        })
+    }
+
+    fn iter_table_hash_prefix(
+        table: &PartitionHandle,
+        prefix: HashPrefix,
+    ) -> RowKeyIter<HASH_PREFIX_ROW_SIZE> {
+        RowKeyIter(Box::new(table.prefix(prefix)))
+    }
+
+    fn config_value<const N: usize>(&self, key: u8) -> Result<Option<[u8; N]>, fjall::Error> {
+        Ok(self.config.get([key])?.map(|v| (&*v).try_into().unwrap()))
+    }
+
+    fn set_config_value<const N: usize>(
+        &self,
+        key: u8,
+        value: [u8; N],
+    ) -> Result<(), fjall::Error> {
+        self.config.insert([key], value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DBStore;
+
+    #[test]
+    fn test_db_prefix_scan() {
+        super::super::test_db_prefix_scan::<DBStore>();
+    }
+}

--- a/src/db/lmdb.rs
+++ b/src/db/lmdb.rs
@@ -9,7 +9,9 @@ use heed::{
     EnvOpenOptions, RoTxn,
 };
 
-use crate::types::{HashPrefix, SerializedHeaderRow, HASH_PREFIX_ROW_SIZE};
+use crate::types::{
+    HashPrefix, SerializedHashPrefixRow, SerializedHeaderRow, HASH_PREFIX_ROW_SIZE,
+};
 
 use super::{Database, WriteBatch};
 
@@ -109,23 +111,25 @@ impl Database for DBStore {
         Ok(this)
     }
 
-    type HashPrefixRowIter<'a> = RowKeyIter<'a, HASH_PREFIX_ROW_SIZE>;
-
-    fn iter_funding(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_funding(
+        &self,
+        prefix: HashPrefix,
+    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         self.iter_table_hash_prefix(&self.funding, prefix)
     }
 
-    fn iter_spending(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_spending(
+        &self,
+        prefix: HashPrefix,
+    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         self.iter_table_hash_prefix(&self.spending, prefix)
     }
 
-    fn iter_txid(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_txid(&self, prefix: HashPrefix) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         self.iter_table_hash_prefix(&self.txid, prefix)
     }
 
-    type HeaderIter<'a> = HeaderIter<'a>;
-
-    fn iter_headers(&self) -> Self::HeaderIter<'_> {
+    fn iter_headers(&self) -> impl Iterator<Item = SerializedHeaderRow> + '_ {
         let rtxn = self.env.clone().static_read_txn().unwrap();
 
         let iter = self

--- a/src/db/lmdb.rs
+++ b/src/db/lmdb.rs
@@ -1,0 +1,247 @@
+use std::{
+    fs::{create_dir_all, remove_file},
+    path::Path,
+};
+
+use anyhow::{Context, Result};
+use heed::{
+    types::{Bytes, Unit, U8},
+    EnvOpenOptions, RoTxn,
+};
+
+use crate::types::{HashPrefix, SerializedHeaderRow, HASH_PREFIX_ROW_SIZE};
+
+use super::{Database, WriteBatch};
+
+const FORMAT_KEY: u8 = b'F';
+const TIP_KEY: u8 = b'T';
+
+const CURRENT_FORMAT: u64 = 0;
+
+// TODO fix
+// field 0 is used in the generated drop code
+#[allow(dead_code)]
+pub struct RowKeyIter<'a, const N: usize>(
+    RoTxn<'static, heed::WithTls>,
+    heed::RoPrefix<'a, Bytes, Unit>,
+);
+
+impl<const N: usize> Iterator for RowKeyIter<'_, N> {
+    type Item = [u8; N];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.1.next().map(|v| v.unwrap().0.try_into().unwrap())
+    }
+}
+
+#[allow(dead_code)]
+pub struct HeaderIter<'a>(RoTxn<'static, heed::WithTls>, heed::RoIter<'a, Bytes, Unit>);
+
+impl Iterator for HeaderIter<'_> {
+    type Item = SerializedHeaderRow;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.1.next().map(|v| v.unwrap().0.try_into().unwrap())
+    }
+}
+
+pub struct DBStore {
+    env: heed::Env,
+    config: heed::Database<U8, Bytes>,
+    headers: heed::Database<Bytes, Unit>,
+    funding: heed::Database<Bytes, Unit>,
+    spending: heed::Database<Bytes, Unit>,
+    txid: heed::Database<Bytes, Unit>,
+}
+
+impl Database for DBStore {
+    fn open(
+        path: &Path,
+        log_dir: Option<&Path>,
+        auto_reindex: bool,
+        _db_parallelism: u8,
+    ) -> Result<Self> {
+        create_dir_all(path).expect("unable to create directories");
+
+        if log_dir.is_some() {
+            info!("ignoring log_dir parameter, it is currently unsupported with lmdb");
+        }
+
+        let mut this = Self::open_internal(path)?;
+
+        let reindex_cause = if let Some(v) = this.config_value(FORMAT_KEY).expect("lmdb read error")
+        {
+            let format = u64::from_be_bytes(v);
+            if format != CURRENT_FORMAT {
+                Some(format!(
+                    "unsupported format {} != {}",
+                    format, CURRENT_FORMAT
+                ))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(cause) = reindex_cause {
+            if !auto_reindex {
+                bail!("re-index required due to {}", cause);
+            }
+            warn!(
+                "Database needs to be re-indexed due to {}, going to delete {}",
+                cause,
+                path.display()
+            );
+            // close DB before deletion
+            drop(this);
+            remove_file(path).with_context(|| {
+                format!(
+                    "re-index required but the old database ({}) can not be deleted",
+                    path.display()
+                )
+            })?;
+            this = Self::open_internal(path)?;
+        }
+
+        this.set_config_value(FORMAT_KEY, CURRENT_FORMAT.to_be_bytes())
+            .expect("lmdb write error");
+        Ok(this)
+    }
+
+    type HashPrefixRowIter<'a> = RowKeyIter<'a, HASH_PREFIX_ROW_SIZE>;
+
+    fn iter_funding(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        self.iter_table_hash_prefix(&self.funding, prefix)
+    }
+
+    fn iter_spending(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        self.iter_table_hash_prefix(&self.spending, prefix)
+    }
+
+    fn iter_txid(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        self.iter_table_hash_prefix(&self.txid, prefix)
+    }
+
+    type HeaderIter<'a> = HeaderIter<'a>;
+
+    fn iter_headers(&self) -> Self::HeaderIter<'_> {
+        let rtxn = self.env.clone().static_read_txn().unwrap();
+
+        let iter = self
+            .headers
+            .iter(
+                // TODO fix
+                unsafe { &*(&rtxn as *const RoTxn<heed::WithTls>) },
+            )
+            .unwrap();
+
+        HeaderIter(rtxn, iter)
+    }
+
+    fn get_tip(&self) -> Option<Vec<u8>> {
+        self.config_value(TIP_KEY)
+            .expect("unable to get tip")
+            .map(|arr: [u8; 32]| arr.to_vec())
+    }
+
+    fn write(&self, batch: &WriteBatch) {
+        fn write_return_error(this: &DBStore, batch: &WriteBatch) -> Result<(), heed::Error> {
+            let mut wtxn = this.env.write_txn()?;
+
+            for key in &batch.funding_rows {
+                this.funding.put(&mut wtxn, key, &())?;
+            }
+
+            for key in &batch.spending_rows {
+                this.spending.put(&mut wtxn, key, &())?;
+            }
+
+            for key in &batch.txid_rows {
+                this.txid.put(&mut wtxn, key, &())?;
+            }
+
+            for key in &batch.header_rows {
+                this.headers.put(&mut wtxn, key, &())?;
+            }
+
+            this.config.put(&mut wtxn, &TIP_KEY, &batch.tip_row)?;
+
+            wtxn.commit()?;
+
+            Ok(())
+        }
+
+        write_return_error(self, batch).expect("lmdb write error");
+    }
+
+    fn flush(&self) {
+        self.env.force_sync().unwrap();
+    }
+
+    fn update_metrics(&self, _gauge: &crate::metrics::Gauge) {
+        // TODO
+    }
+}
+
+impl DBStore {
+    fn open_internal(path: &Path) -> Result<Self, heed::Error> {
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(1024 * 1024 * 1024 * 1024)
+                .max_dbs(5)
+                .open(path)?
+        };
+
+        let mut wtxn = env.write_txn()?;
+
+        let config = env.create_database(&mut wtxn, Some("config"))?;
+        let headers = env.create_database(&mut wtxn, Some("headers"))?;
+        let funding = env.create_database(&mut wtxn, Some("funding"))?;
+        let spending = env.create_database(&mut wtxn, Some("spending"))?;
+        let txid = env.create_database(&mut wtxn, Some("txid"))?;
+
+        wtxn.commit()?;
+
+        Ok(Self {
+            env,
+            config,
+            headers,
+            funding,
+            spending,
+            txid,
+        })
+    }
+
+    fn iter_table_hash_prefix(
+        &self,
+        db: &heed::Database<Bytes, Unit>,
+        prefix: HashPrefix,
+    ) -> RowKeyIter<'_, HASH_PREFIX_ROW_SIZE> {
+        let rtxn = self.env.clone().static_read_txn().unwrap();
+
+        let iter = db
+            .prefix_iter(
+                // TODO fix
+                unsafe { &*(&rtxn as *const RoTxn<heed::WithTls>) },
+                &prefix,
+            )
+            .unwrap();
+
+        RowKeyIter(rtxn, iter)
+    }
+
+    fn config_value<const N: usize>(&self, key: u8) -> Result<Option<[u8; N]>, heed::Error> {
+        let rtxn = self.env.read_txn()?;
+
+        Ok(self.config.get(&rtxn, &key)?.map(|v| v.try_into().unwrap()))
+    }
+
+    fn set_config_value<const N: usize>(&self, key: u8, value: [u8; N]) -> Result<(), heed::Error> {
+        let mut wtxn = self.env.write_txn()?;
+        self.config.put(&mut wtxn, &key, &value)?;
+        wtxn.commit()?;
+
+        Ok(())
+    }
+}

--- a/src/db/lmdb.rs
+++ b/src/db/lmdb.rs
@@ -278,3 +278,13 @@ impl DBStore {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::DBStore;
+
+    #[test]
+    fn test_db_prefix_scan() {
+        super::super::test_db_prefix_scan::<DBStore>();
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -10,15 +10,19 @@ pub mod redb;
 #[cfg(feature = "sled")]
 pub mod sled;
 
+#[cfg(feature = "fjall")]
+pub mod fjall;
+
 #[cfg(not(any(
     feature = "rocksdb",
     feature = "lmdb",
     feature = "redb",
     feature = "sled",
+    feature = "fjall",
 )))]
 compile_error!(
     "Tried to build electrs without database, but at least one is needed. \
-     Enable at least one of the following features: 'rocksdb', 'lmdb', 'redb', 'sled'."
+     Enable at least one of the following features: 'rocksdb', 'lmdb', 'redb', 'sled', 'fjall'."
 );
 
 use anyhow::Result;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -60,21 +60,19 @@ pub trait Database: Sized + Sync {
         db_parallelism: u8,
     ) -> Result<Self>;
 
-    type HashPrefixRowIter<'a>: Iterator<Item = SerializedHashPrefixRow> + 'a
-    where
-        Self: 'a;
+    fn iter_funding(
+        &self,
+        prefix: HashPrefix,
+    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_;
 
-    fn iter_funding(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_>;
+    fn iter_spending(
+        &self,
+        prefix: HashPrefix,
+    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_;
 
-    fn iter_spending(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_>;
+    fn iter_txid(&self, prefix: HashPrefix) -> impl Iterator<Item = SerializedHashPrefixRow> + '_;
 
-    fn iter_txid(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_>;
-
-    type HeaderIter<'a>: Iterator<Item = SerializedHeaderRow> + 'a
-    where
-        Self: 'a;
-
-    fn iter_headers(&self) -> Self::HeaderIter<'_>;
+    fn iter_headers(&self) -> impl Iterator<Item = SerializedHeaderRow> + '_;
 
     fn get_tip(&self) -> Option<Vec<u8>>;
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,16 +1,24 @@
 #[cfg(feature = "rocksdb")]
 pub mod rocksdb;
 
+#[cfg(feature = "lmdb")]
+pub mod lmdb;
+
 #[cfg(feature = "redb")]
 pub mod redb;
 
 #[cfg(feature = "sled")]
 pub mod sled;
 
-#[cfg(not(any(feature = "rocksdb", feature = "redb", feature = "sled",)))]
+#[cfg(not(any(
+    feature = "rocksdb",
+    feature = "lmdb",
+    feature = "redb",
+    feature = "sled",
+)))]
 compile_error!(
     "Tried to build electrs without database, but at least one is needed. \
-     Enable at least one of the following features: 'rocksdb', 'redb', 'sled'."
+     Enable at least one of the following features: 'rocksdb', 'lmdb', 'redb', 'sled'."
 );
 
 use anyhow::Result;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,10 +4,13 @@ pub mod rocksdb;
 #[cfg(feature = "redb")]
 pub mod redb;
 
-#[cfg(not(any(feature = "rocksdb", feature = "redb",)))]
+#[cfg(feature = "sled")]
+pub mod sled;
+
+#[cfg(not(any(feature = "rocksdb", feature = "redb", feature = "sled",)))]
 compile_error!(
     "Tried to build electrs without database, but at least one is needed. \
-     Enable at least one of the following features: 'rocksdb', 'redb'."
+     Enable at least one of the following features: 'rocksdb', 'redb', 'sled'."
 );
 
 use anyhow::Result;

--- a/src/db/redb.rs
+++ b/src/db/redb.rs
@@ -1,6 +1,6 @@
 use super::{hash_prefix_range, Database, WriteBatch};
 use crate::types::{
-    HashPrefix, SerializedHashPrefixRow, SerializedHeaderRow, HASH_PREFIX_ROW_SIZE, HEADER_ROW_SIZE,
+    HashPrefix, SerializedHashPrefixRow, SerializedHeaderRow, HASH_PREFIX_ROW_SIZE,
 };
 use anyhow::{Context, Result};
 use redb::{ReadableTableMetadata, TableDefinition, TableHandle};
@@ -105,23 +105,25 @@ impl Database for DBStore {
         Ok(this)
     }
 
-    type HashPrefixRowIter<'a> = RowKeyIter<'a, HASH_PREFIX_ROW_SIZE>;
-
-    fn iter_funding(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_funding(
+        &self,
+        prefix: HashPrefix,
+    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         self.iter_table_hash_prefix(FUNDING_TABLE, prefix)
     }
 
-    fn iter_spending(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_spending(
+        &self,
+        prefix: HashPrefix,
+    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         self.iter_table_hash_prefix(SPENDING_TABLE, prefix)
     }
 
-    fn iter_txid(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_txid(&self, prefix: HashPrefix) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         self.iter_table_hash_prefix(TXID_TABLE, prefix)
     }
 
-    type HeaderIter<'a> = RowKeyIter<'a, HEADER_ROW_SIZE>;
-
-    fn iter_headers(&self) -> Self::HeaderIter<'_> {
+    fn iter_headers(&self) -> impl Iterator<Item = SerializedHeaderRow> + '_ {
         let read_txn = self
             .db
             .begin_read()

--- a/src/db/redb.rs
+++ b/src/db/redb.rs
@@ -1,0 +1,249 @@
+use super::{hash_prefix_range, Database, WriteBatch};
+use crate::types::{
+    HashPrefix, SerializedHashPrefixRow, SerializedHeaderRow, HASH_PREFIX_ROW_SIZE, HEADER_ROW_SIZE,
+};
+use anyhow::{Context, Result};
+use redb::TableDefinition;
+use std::fs::{create_dir_all, remove_file};
+use std::path::Path;
+
+const CONFIG_TABLE: TableDefinition<u8, &[u8]> = TableDefinition::new("config");
+const HEADERS_TABLE: TableDefinition<SerializedHeaderRow, ()> = TableDefinition::new("headers");
+const FUNDING_TABLE: TableDefinition<SerializedHashPrefixRow, ()> = TableDefinition::new("funding");
+const SPENDING_TABLE: TableDefinition<SerializedHashPrefixRow, ()> =
+    TableDefinition::new("spending");
+const TXID_TABLE: TableDefinition<SerializedHashPrefixRow, ()> = TableDefinition::new("txid");
+
+const FORMAT_KEY: u8 = b'F';
+const TIP_KEY: u8 = b'T';
+
+const CURRENT_FORMAT: u64 = 0;
+
+pub struct RowKeyIter<'a, const N: usize>(redb::Range<'a, [u8; N], ()>);
+
+impl<const N: usize> Iterator for RowKeyIter<'_, N> {
+    type Item = [u8; N];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|v| v.unwrap().0.value())
+    }
+}
+
+pub struct DBStore {
+    db: redb::Database,
+}
+
+impl Database for DBStore {
+    fn open(
+        path: &Path,
+        log_dir: Option<&Path>,
+        auto_reindex: bool,
+        _db_parallelism: u8,
+    ) -> Result<Self> {
+        create_dir_all(path).expect("unable to create directories");
+
+        if log_dir.is_some() {
+            info!("ignoring log_dir parameter, it is currently unsupported with redb");
+        }
+
+        let path = path.join("electrs.redb");
+        let mut this = Self::open_internal(&path)?;
+
+        fn create_tables(db: &redb::Database) -> Result<(), redb::Error> {
+            let write_txn = db.begin_write()?;
+
+            write_txn.open_table(FUNDING_TABLE)?;
+            write_txn.open_table(SPENDING_TABLE)?;
+            write_txn.open_table(TXID_TABLE)?;
+            write_txn.open_table(HEADERS_TABLE)?;
+            write_txn.open_table(CONFIG_TABLE)?;
+
+            write_txn.commit()?;
+
+            Ok(())
+        }
+
+        create_tables(&this.db).expect("unable to create tables");
+
+        let reindex_cause = if let Some(v) = this.config_value(FORMAT_KEY).expect("redb read error")
+        {
+            let format = u64::from_be_bytes(v);
+            if format != CURRENT_FORMAT {
+                Some(format!(
+                    "unsupported format {} != {}",
+                    format, CURRENT_FORMAT
+                ))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(cause) = reindex_cause {
+            if !auto_reindex {
+                bail!("re-index required due to {}", cause);
+            }
+            warn!(
+                "Database needs to be re-indexed due to {}, going to delete {}",
+                cause,
+                path.display()
+            );
+            // close DB before deletion
+            drop(this);
+            remove_file(&path).with_context(|| {
+                format!(
+                    "re-index required but the old database ({}) can not be deleted",
+                    path.display()
+                )
+            })?;
+            this = Self::open_internal(&path)?;
+        }
+
+        this.set_config_value(FORMAT_KEY, CURRENT_FORMAT.to_be_bytes())
+            .expect("redb write error");
+        Ok(this)
+    }
+
+    type HashPrefixRowIter<'a> = RowKeyIter<'a, HASH_PREFIX_ROW_SIZE>;
+
+    fn iter_funding(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        self.iter_table_hash_prefix(FUNDING_TABLE, prefix)
+    }
+
+    fn iter_spending(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        self.iter_table_hash_prefix(SPENDING_TABLE, prefix)
+    }
+
+    fn iter_txid(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        self.iter_table_hash_prefix(TXID_TABLE, prefix)
+    }
+
+    type HeaderIter<'a> = RowKeyIter<'a, HEADER_ROW_SIZE>;
+
+    fn iter_headers(&self) -> Self::HeaderIter<'_> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .expect("unable to create read transaction");
+        let table = read_txn
+            .open_table(HEADERS_TABLE)
+            .expect("unable to open table");
+
+        RowKeyIter(
+            table
+                .range::<SerializedHeaderRow>(..)
+                .expect("unable to create range iterator"),
+        )
+    }
+
+    fn get_tip(&self) -> Option<Vec<u8>> {
+        self.config_value(TIP_KEY)
+            .expect("unable to get tip")
+            .map(|arr: [u8; 32]| arr.to_vec())
+    }
+
+    fn write(&self, batch: &WriteBatch) {
+        fn write_return_error(db: &redb::Database, batch: &WriteBatch) -> Result<(), redb::Error> {
+            let write_txn = db.begin_write()?;
+            // TODO try this
+            // write_txn.set_durability(redb::Durability::None);
+            {
+                let mut table = write_txn.open_table(FUNDING_TABLE)?;
+                for key in &batch.funding_rows {
+                    table.insert(key, ())?;
+                }
+
+                let mut table = write_txn.open_table(SPENDING_TABLE)?;
+                for key in &batch.spending_rows {
+                    table.insert(key, ())?;
+                }
+
+                let mut table = write_txn.open_table(TXID_TABLE)?;
+                for key in &batch.txid_rows {
+                    table.insert(key, ())?;
+                }
+
+                let mut table = write_txn.open_table(HEADERS_TABLE)?;
+                for key in &batch.header_rows {
+                    table.insert(key, ())?;
+                }
+
+                let mut table = write_txn.open_table(CONFIG_TABLE)?;
+                table.insert(TIP_KEY, &batch.tip_row as &[u8])?;
+            }
+
+            write_txn.commit()?;
+
+            Ok(())
+        }
+
+        write_return_error(&self.db, batch).expect("redb write error");
+    }
+
+    fn flush(&self) {
+        // TODO?
+    }
+
+    fn update_metrics(&self, _gauge: &crate::metrics::Gauge) {
+        // TODO do something with table stats
+
+        // let read_txn = self
+        //     .db
+        //     .begin_read()
+        //     .expect("unable to create read transaction");
+        // let table = read_txn
+        //     .open_table(FUNDING_TABLE)
+        //     .expect("unable to open table");
+        // let stats = table.stats().expect("unable to get table stats");
+    }
+}
+
+impl DBStore {
+    fn open_internal(path: &Path) -> Result<Self, redb::Error> {
+        const GIGABYTE: usize = 1024 * 1024 * 1024;
+
+        Ok(Self {
+            db: redb::Database::builder()
+                .set_cache_size(4 * GIGABYTE)
+                .create(path)?,
+        })
+    }
+
+    fn iter_table_hash_prefix(
+        &self,
+        table_definition: TableDefinition<SerializedHashPrefixRow, ()>,
+        prefix: HashPrefix,
+    ) -> RowKeyIter<'_, HASH_PREFIX_ROW_SIZE> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .expect("unable to create read transaction");
+        let table = read_txn
+            .open_table(table_definition)
+            .expect("unable to open table");
+
+        RowKeyIter(
+            table
+                .range(hash_prefix_range(prefix))
+                .expect("unable to create range iterator"),
+        )
+    }
+
+    fn config_value<const N: usize>(&self, key: u8) -> Result<Option<[u8; N]>, redb::Error> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(CONFIG_TABLE)?;
+        Ok(table.get(key)?.map(|v| v.value().try_into().unwrap()))
+    }
+
+    fn set_config_value<const N: usize>(&self, key: u8, value: [u8; N]) -> Result<(), redb::Error> {
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut table = write_txn.open_table(CONFIG_TABLE)?;
+            table.insert(key, &value as &[u8])?;
+        }
+        write_txn.commit()?;
+
+        Ok(())
+    }
+}

--- a/src/db/redb.rs
+++ b/src/db/redb.rs
@@ -276,3 +276,13 @@ impl DBStore {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::DBStore;
+
+    #[test]
+    fn test_db_prefix_scan() {
+        super::super::test_db_prefix_scan::<DBStore>();
+    }
+}

--- a/src/db/rocksdb.rs
+++ b/src/db/rocksdb.rs
@@ -4,7 +4,9 @@ use rust_rocksdb as rocksdb;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::types::{HashPrefix, HASH_PREFIX_ROW_SIZE, HEADER_ROW_SIZE};
+use crate::types::{
+    HashPrefix, SerializedHashPrefixRow, SerializedHeaderRow, HASH_PREFIX_ROW_SIZE, HEADER_ROW_SIZE,
+};
 
 use super::{Database, WriteBatch};
 
@@ -110,23 +112,25 @@ impl Database for DBStore {
         Self::open(path, log_dir, auto_reindex, db_parallelism)
     }
 
-    type HashPrefixRowIter<'a> = DBIterator<'a, HASH_PREFIX_ROW_SIZE>;
-
-    fn iter_funding(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_funding(
+        &self,
+        prefix: HashPrefix,
+    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         self.iter_funding(prefix)
     }
 
-    fn iter_spending(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_spending(
+        &self,
+        prefix: HashPrefix,
+    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         self.iter_spending(prefix)
     }
 
-    fn iter_txid(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_txid(&self, prefix: HashPrefix) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         self.iter_txid(prefix)
     }
 
-    type HeaderIter<'a> = DBIterator<'a, HEADER_ROW_SIZE>;
-
-    fn iter_headers(&self) -> Self::HeaderIter<'_> {
+    fn iter_headers(&self) -> impl Iterator<Item = SerializedHeaderRow> + '_ {
         self.iter_headers()
     }
 

--- a/src/db/rocksdb.rs
+++ b/src/db/rocksdb.rs
@@ -4,25 +4,9 @@ use rust_rocksdb as rocksdb;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::types::{HashPrefix, SerializedHashPrefixRow, SerializedHeaderRow};
+use crate::types::{HashPrefix, HASH_PREFIX_ROW_SIZE, HEADER_ROW_SIZE};
 
-#[derive(Default)]
-pub(crate) struct WriteBatch {
-    pub(crate) tip_row: [u8; 32],
-    pub(crate) header_rows: Vec<SerializedHeaderRow>,
-    pub(crate) funding_rows: Vec<SerializedHashPrefixRow>,
-    pub(crate) spending_rows: Vec<SerializedHashPrefixRow>,
-    pub(crate) txid_rows: Vec<SerializedHashPrefixRow>,
-}
-
-impl WriteBatch {
-    pub(crate) fn sort(&mut self) {
-        self.header_rows.sort_unstable();
-        self.funding_rows.sort_unstable();
-        self.spending_rows.sort_unstable();
-        self.txid_rows.sort_unstable();
-    }
-}
+use super::{Database, WriteBatch};
 
 /// RocksDB wrapper for index storage
 pub struct DBStore {
@@ -114,6 +98,55 @@ fn default_opts(parallelism: u8) -> rocksdb::Options {
     opts.set_prefix_extractor(rocksdb::SliceTransform::create_fixed_prefix(8));
     opts.set_block_based_table_factory(&block_opts);
     opts
+}
+
+impl Database for DBStore {
+    fn open(
+        path: &Path,
+        log_dir: Option<&Path>,
+        auto_reindex: bool,
+        db_parallelism: u8,
+    ) -> Result<Self> {
+        Self::open(path, log_dir, auto_reindex, db_parallelism)
+    }
+
+    type HashPrefixRowIter<'a> = DBIterator<'a, HASH_PREFIX_ROW_SIZE>;
+
+    fn iter_funding(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        self.iter_funding(prefix)
+    }
+
+    fn iter_spending(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        self.iter_spending(prefix)
+    }
+
+    fn iter_txid(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        self.iter_txid(prefix)
+    }
+
+    type HeaderIter<'a> = DBIterator<'a, HEADER_ROW_SIZE>;
+
+    fn iter_headers(&self) -> Self::HeaderIter<'_> {
+        self.iter_headers()
+    }
+
+    fn get_tip(&self) -> Option<Vec<u8>> {
+        self.get_tip()
+    }
+
+    fn write(&self, batch: &WriteBatch) {
+        self.write(batch);
+    }
+
+    fn flush(&self) {
+        self.flush();
+    }
+
+    fn update_metrics(&self, gauge: &crate::metrics::Gauge) {
+        for (cf, name, value) in self.get_properties() {
+            gauge.set(&format!("{}:{}", name, cf), value as f64);
+        }
+    }
 }
 
 impl DBStore {
@@ -230,24 +263,15 @@ impl DBStore {
         self.db.cf_handle(HEADERS_CF).expect("missing HEADERS_CF")
     }
 
-    pub(crate) fn iter_funding(
-        &self,
-        prefix: HashPrefix,
-    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
+    pub(crate) fn iter_funding(&self, prefix: HashPrefix) -> DBIterator<'_, HASH_PREFIX_ROW_SIZE> {
         self.iter_prefix_cf(self.funding_cf(), prefix)
     }
 
-    pub(crate) fn iter_spending(
-        &self,
-        prefix: HashPrefix,
-    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
+    pub(crate) fn iter_spending(&self, prefix: HashPrefix) -> DBIterator<'_, HASH_PREFIX_ROW_SIZE> {
         self.iter_prefix_cf(self.spending_cf(), prefix)
     }
 
-    pub(crate) fn iter_txid(
-        &self,
-        prefix: HashPrefix,
-    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
+    pub(crate) fn iter_txid(&self, prefix: HashPrefix) -> DBIterator<'_, HASH_PREFIX_ROW_SIZE> {
         self.iter_prefix_cf(self.txid_cf(), prefix)
     }
 
@@ -256,7 +280,7 @@ impl DBStore {
         cf: &rocksdb::ColumnFamily,
         readopts: rocksdb::ReadOptions,
         prefix: Option<HashPrefix>,
-    ) -> impl Iterator<Item = [u8; N]> + '_ {
+    ) -> DBIterator<'_, N> {
         DBIterator::new(self.db.raw_iterator_cf_opt(cf, readopts), prefix)
     }
 
@@ -264,13 +288,13 @@ impl DBStore {
         &self,
         cf: &rocksdb::ColumnFamily,
         prefix: HashPrefix,
-    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
+    ) -> DBIterator<'_, HASH_PREFIX_ROW_SIZE> {
         let mut opts = rocksdb::ReadOptions::default();
         opts.set_prefix_same_as_start(true); // requires .set_prefix_extractor() above.
         self.iter_cf(cf, opts, Some(prefix))
     }
 
-    pub(crate) fn iter_headers(&self) -> impl Iterator<Item = SerializedHeaderRow> + '_ {
+    pub(crate) fn iter_headers(&self) -> DBIterator<'_, HEADER_ROW_SIZE> {
         let mut opts = rocksdb::ReadOptions::default();
         opts.fill_cache(false);
         self.iter_cf(self.headers_cf(), opts, None)
@@ -377,7 +401,7 @@ impl DBStore {
     }
 }
 
-struct DBIterator<'a, const N: usize> {
+pub struct DBIterator<'a, const N: usize> {
     raw: rocksdb::DBRawIterator<'a>,
     prefix: Option<HashPrefix>,
     done: bool,

--- a/src/db/rocksdb.rs
+++ b/src/db/rocksdb.rs
@@ -460,7 +460,7 @@ impl Drop for DBStore {
 
 #[cfg(test)]
 mod tests {
-    use super::{rocksdb, DBStore, WriteBatch, CURRENT_FORMAT};
+    use super::{rocksdb, DBStore, CURRENT_FORMAT};
     use std::ffi::{OsStr, OsString};
     use std::path::Path;
 
@@ -519,27 +519,7 @@ mod tests {
 
     #[test]
     fn test_db_prefix_scan() {
-        let dir = tempfile::tempdir().unwrap();
-        let store = DBStore::open(dir.path(), None, true, 1).unwrap();
-
-        let items = [
-            *b"ab          ",
-            *b"abcdefgh    ",
-            *b"abcdefghj   ",
-            *b"abcdefghjk  ",
-            *b"abcdefghxyz ",
-            *b"abcdefgi    ",
-            *b"b           ",
-            *b"c           ",
-        ];
-
-        store.write(&WriteBatch {
-            txid_rows: items.to_vec(),
-            ..Default::default()
-        });
-
-        let rows = store.iter_txid(*b"abcdefgh");
-        assert_eq!(rows.collect::<Vec<_>>(), items[1..5]);
+        super::super::test_db_prefix_scan::<DBStore>();
     }
 
     #[test]

--- a/src/db/sled.rs
+++ b/src/db/sled.rs
@@ -6,7 +6,7 @@ use sled::Batch;
 
 use super::{hash_prefix_range, Database, WriteBatch};
 
-use crate::types::{HashPrefix, SerializedHeaderRow, HASH_PREFIX_ROW_SIZE, HEADER_ROW_SIZE};
+use crate::types::{HashPrefix, SerializedHashPrefixRow, SerializedHeaderRow};
 
 const FORMAT_KEY: u8 = b'F';
 const TIP_KEY: u8 = b'T';
@@ -86,23 +86,25 @@ impl Database for DBStore {
         Ok(this)
     }
 
-    type HashPrefixRowIter<'a> = RowKeyIter<HASH_PREFIX_ROW_SIZE>;
-
-    fn iter_funding(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_funding(
+        &self,
+        prefix: HashPrefix,
+    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         RowKeyIter(self.funding.range(hash_prefix_range(prefix)))
     }
 
-    fn iter_spending(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_spending(
+        &self,
+        prefix: HashPrefix,
+    ) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         RowKeyIter(self.spending.range(hash_prefix_range(prefix)))
     }
 
-    fn iter_txid(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+    fn iter_txid(&self, prefix: HashPrefix) -> impl Iterator<Item = SerializedHashPrefixRow> + '_ {
         RowKeyIter(self.txid.range(hash_prefix_range(prefix)))
     }
 
-    type HeaderIter<'a> = RowKeyIter<HEADER_ROW_SIZE>;
-
-    fn iter_headers(&self) -> Self::HeaderIter<'_> {
+    fn iter_headers(&self) -> impl Iterator<Item = SerializedHeaderRow> + '_ {
         RowKeyIter(self.headers.range::<SerializedHeaderRow, _>(..))
     }
 

--- a/src/db/sled.rs
+++ b/src/db/sled.rs
@@ -1,0 +1,200 @@
+use std::fs::{create_dir_all, remove_dir_all};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use sled::Batch;
+
+use super::{hash_prefix_range, Database, WriteBatch};
+
+use crate::types::{HashPrefix, SerializedHeaderRow, HASH_PREFIX_ROW_SIZE, HEADER_ROW_SIZE};
+
+const FORMAT_KEY: u8 = b'F';
+const TIP_KEY: u8 = b'T';
+
+const CURRENT_FORMAT: u64 = 0;
+
+pub struct RowKeyIter<const N: usize>(sled::Iter);
+
+impl<const N: usize> Iterator for RowKeyIter<N> {
+    type Item = [u8; N];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|v| (&*v.unwrap().0).try_into().unwrap())
+    }
+}
+
+pub struct DBStore {
+    config: sled::Tree,
+    headers: sled::Tree,
+    funding: sled::Tree,
+    spending: sled::Tree,
+    txid: sled::Tree,
+}
+
+impl Database for DBStore {
+    fn open(
+        path: &Path,
+        log_dir: Option<&Path>,
+        auto_reindex: bool,
+        _db_parallelism: u8,
+    ) -> Result<Self> {
+        create_dir_all(path).expect("unable to create directories");
+
+        if log_dir.is_some() {
+            info!("ignoring log_dir parameter, it is currently unsupported with sled");
+        }
+
+        let mut this = Self::open_internal(path)?;
+
+        let format = this
+            .config_value(FORMAT_KEY)?
+            .map(u64::from_be_bytes)
+            .unwrap_or(CURRENT_FORMAT);
+        let reindex_cause = if format != CURRENT_FORMAT {
+            Some(format!(
+                "unsupported format {} != {}",
+                format, CURRENT_FORMAT
+            ))
+        } else {
+            None
+        };
+
+        if let Some(cause) = reindex_cause {
+            if !auto_reindex {
+                bail!("re-index required due to {}", cause);
+            }
+            warn!(
+                "Database needs to be re-indexed due to {}, going to delete {}",
+                cause,
+                path.display()
+            );
+            // close DB before deletion
+            drop(this);
+            remove_dir_all(path).with_context(|| {
+                format!(
+                    "re-index required but the old database ({}) can not be deleted",
+                    path.display()
+                )
+            })?;
+            this = Self::open_internal(path)?;
+        }
+
+        this.set_config_value(FORMAT_KEY, format.to_be_bytes())
+            .expect("unable to write format");
+
+        Ok(this)
+    }
+
+    type HashPrefixRowIter<'a> = RowKeyIter<HASH_PREFIX_ROW_SIZE>;
+
+    fn iter_funding(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        RowKeyIter(self.funding.range(hash_prefix_range(prefix)))
+    }
+
+    fn iter_spending(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        RowKeyIter(self.spending.range(hash_prefix_range(prefix)))
+    }
+
+    fn iter_txid(&self, prefix: HashPrefix) -> Self::HashPrefixRowIter<'_> {
+        RowKeyIter(self.txid.range(hash_prefix_range(prefix)))
+    }
+
+    type HeaderIter<'a> = RowKeyIter<HEADER_ROW_SIZE>;
+
+    fn iter_headers(&self) -> Self::HeaderIter<'_> {
+        RowKeyIter(self.headers.range::<SerializedHeaderRow, _>(..))
+    }
+
+    fn get_tip(&self) -> Option<Vec<u8>> {
+        self.config_value(TIP_KEY)
+            .expect("unable to read tip")
+            .map(|t: [u8; 32]| t.to_vec())
+    }
+
+    fn write(&self, batch: &WriteBatch) {
+        // TODO associated type to not have to transfer all data from WriteBatch to sled::Batch
+
+        {
+            let mut headers_batch = Batch::default();
+            for key in &batch.header_rows {
+                headers_batch.insert(key as &[u8], &[]);
+            }
+
+            self.headers
+                .apply_batch(headers_batch)
+                .expect("sled write error");
+        }
+
+        {
+            let mut funding_batch = Batch::default();
+            for key in &batch.funding_rows {
+                funding_batch.insert(key, &[]);
+            }
+
+            self.funding
+                .apply_batch(funding_batch)
+                .expect("sled write error");
+        }
+
+        {
+            let mut spending_batch = Batch::default();
+            for key in &batch.spending_rows {
+                spending_batch.insert(key, &[]);
+            }
+
+            self.spending
+                .apply_batch(spending_batch)
+                .expect("sled write error");
+        }
+
+        {
+            let mut txid_batch = Batch::default();
+            for key in &batch.txid_rows {
+                txid_batch.insert(key, &[]);
+            }
+
+            self.txid.apply_batch(txid_batch).expect("sled write error");
+        }
+
+        self.set_config_value(TIP_KEY, batch.tip_row)
+            .expect("unable to write tip");
+    }
+
+    fn flush(&self) {
+        // TODO
+
+        self.config.flush().expect("config flush failed");
+        self.headers.flush().expect("headers flush failed");
+        self.funding.flush().expect("funding flush failed");
+        self.spending.flush().expect("spending flush failed");
+        self.txid.flush().expect("txid flush failed");
+    }
+
+    fn update_metrics(&self, _gauge: &crate::metrics::Gauge) {
+        // TODO
+    }
+}
+
+impl DBStore {
+    fn open_internal(path: &Path) -> Result<Self> {
+        // TODO config
+        let db = sled::Config::new().path(path).open()?;
+
+        Ok(Self {
+            config: db.open_tree("config")?,
+            headers: db.open_tree("headers")?,
+            funding: db.open_tree("funding")?,
+            spending: db.open_tree("spending")?,
+            txid: db.open_tree("txid")?,
+        })
+    }
+
+    fn config_value<const N: usize>(&self, key: u8) -> Result<Option<[u8; N]>, sled::Error> {
+        Ok(self.config.get([key])?.map(|v| (&*v).try_into().unwrap()))
+    }
+
+    fn set_config_value<const N: usize>(&self, key: u8, value: [u8; N]) -> Result<(), sled::Error> {
+        self.config.insert([key], &value as &[u8])?;
+        Ok(())
+    }
+}

--- a/src/db/sled.rs
+++ b/src/db/sled.rs
@@ -203,3 +203,13 @@ impl DBStore {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::DBStore;
+
+    #[test]
+    fn test_db_prefix_scan() {
+        super::super::test_db_prefix_scan::<DBStore>();
+    }
+}

--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -19,6 +19,7 @@ use crate::{
     cache::Cache,
     config::{Config, ELECTRS_VERSION},
     daemon::{self, extract_bitcoind_error, Daemon},
+    db::Database,
     merkle::Proof,
     metrics::{self, Histogram, Metrics},
     signals::Signal,
@@ -120,8 +121,8 @@ impl RpcError {
 }
 
 /// Electrum RPC handler
-pub struct Rpc {
-    tracker: Tracker,
+pub struct Rpc<D> {
+    tracker: Tracker<D>,
     cache: Cache,
     rpc_duration: Histogram,
     daemon: Daemon,
@@ -130,7 +131,7 @@ pub struct Rpc {
     port: u16,
 }
 
-impl Rpc {
+impl<D: Database> Rpc<D> {
     /// Perform initial index sync (may take a while on first run).
     pub fn new(config: &Config, metrics: Metrics) -> Result<Self> {
         let rpc_duration = metrics.histogram_vec(

--- a/src/server.rs
+++ b/src/server.rs
@@ -106,6 +106,11 @@ fn serve() -> Result<()> {
             let rpc = Rpc::<crate::db::sled::DBStore>::new(&config, metrics)?;
             server_loop(rpc, server_rx, server_batch_size, duration, config)
         }
+        #[cfg(feature = "fjall")]
+        DatabaseType::Fjall => {
+            let rpc = Rpc::<crate::db::fjall::DBStore>::new(&config, metrics)?;
+            server_loop(rpc, server_rx, server_batch_size, duration, config)
+        }
         #[allow(unreachable_patterns)]
         _ => {
             Err(anyhow!("this build does not support using {} because that feature was not enabled at compile time", config.database))

--- a/src/server.rs
+++ b/src/server.rs
@@ -96,6 +96,11 @@ fn serve() -> Result<()> {
             let rpc = Rpc::<crate::db::redb::DBStore>::new(&config, metrics)?;
             server_loop(rpc, server_rx, server_batch_size, duration, config)
         }
+        #[cfg(feature = "sled")]
+        DatabaseType::Sled => {
+            let rpc = Rpc::<crate::db::sled::DBStore>::new(&config, metrics)?;
+            server_loop(rpc, server_rx, server_batch_size, duration, config)
+        }
         #[allow(unreachable_patterns)]
         _ => {
             Err(anyhow!("this build does not support using {} because that feature was not enabled at compile time", config.database))

--- a/src/server.rs
+++ b/src/server.rs
@@ -91,6 +91,11 @@ fn serve() -> Result<()> {
             let rpc = Rpc::<crate::db::rocksdb::DBStore>::new(&config, metrics)?;
             server_loop(rpc, server_rx, server_batch_size, duration, config)
         }
+        #[cfg(feature = "lmdb")]
+        DatabaseType::LMDB => {
+            let rpc = Rpc::<crate::db::lmdb::DBStore>::new(&config, metrics)?;
+            server_loop(rpc, server_rx, server_batch_size, duration, config)
+        }
         #[cfg(feature = "redb")]
         DatabaseType::ReDB => {
             let rpc = Rpc::<crate::db::redb::DBStore>::new(&config, metrics)?;

--- a/src/status.rs
+++ b/src/status.rs
@@ -18,6 +18,7 @@ use crate::{
     cache::Cache,
     chain::Chain,
     daemon::Daemon,
+    db::Database,
     index::Index,
     mempool::Mempool,
     types::{bsl_txid, ScriptHash, SerBlock, StatusHash},
@@ -329,7 +330,7 @@ impl ScriptHashStatus {
     /// Also cache relevant transactions and their merkle proofs.
     fn sync_confirmed(
         &self,
-        index: &Index,
+        index: &Index<impl Database>,
         daemon: &Daemon,
         cache: &Cache,
         outpoints: &mut HashSet<OutPoint>,
@@ -425,7 +426,7 @@ impl ScriptHashStatus {
     /// After a successful sync, scripthash status is updated.
     pub(crate) fn sync(
         &mut self,
-        index: &Index,
+        index: &Index<impl Database>,
         mempool: &Mempool,
         daemon: &Daemon,
         cache: &Cache,

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -9,7 +9,7 @@ use crate::{
     chain::Chain,
     config::Config,
     daemon::Daemon,
-    db::DBStore,
+    db::Database,
     index::Index,
     mempool::{FeeHistogram, Mempool},
     metrics::Metrics,
@@ -19,8 +19,8 @@ use crate::{
 };
 
 /// Electrum protocol subscriptions' tracker
-pub struct Tracker {
-    index: Index,
+pub struct Tracker<D> {
+    index: Index<D>,
     mempool: Mempool,
     metrics: Metrics,
     ignore_mempool: bool,
@@ -30,9 +30,9 @@ pub(crate) enum Error {
     NotReady,
 }
 
-impl Tracker {
+impl<D: Database> Tracker<D> {
     pub fn new(config: &Config, metrics: Metrics) -> Result<Self> {
-        let store = DBStore::open(
+        let store = D::open(
             &config.db_path,
             config.db_log_dir.as_deref(),
             config.auto_reindex,


### PR DESCRIPTION
depends on #1043 because fixed size datatypes made this pr easier
depends on #1125 because some database crates require a higher msrv than 1.63

a bit inspired by #765, only not trying to get a dozen DBs to work at once, and not using any dynamic dispatch

still experimental because it performed a bit worse than rocksdb in my initial try (indexing on the signet), but that could be due to other factors as well (both were running from the same bitcoind so one might have gotten prioritized maybe?)

there is a few TODOs still (like metrics from the db) and probably some configuration still needed to get more speed out of the hardware

the `Database` trait defines all things the rest of electrs can do with a database backend, so more databases can be added later, even a built in in-memory db maybe for automated testing or just quick regtest setup