### PR TITLE
[POC/WIP] Add optional Bip352 silentpayments index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,24 +4,24 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii"
@@ -31,9 +31,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "base58ck"
@@ -80,8 +80,7 @@ dependencies = [
 [[package]]
 name = "bitcoin"
 version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
+source = "git+https://github.com/jlest01/rust-bitcoin.git?branch=bip352-silentpayments-module-v0#5ae56d12a54e15b6564cac22fa1ee2c0b2bb2ce7"
 dependencies = [
  "base58ck",
  "bech32",
@@ -118,9 +117,9 @@ checksum = "0c188654f9dce3bc6ce1bfa9c49777ad514bcad37e421b5f53e9d0ee10603f34"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb54da0b28892f3c52203a7191534033e051b6f4b52bc15480681b57b7e036f5"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
  "bitcoin-internals",
  "serde",
@@ -140,8 +139,7 @@ dependencies = [
 [[package]]
 name = "bitcoin_slices"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8041a1be831c809ada090db2e3bd1469c65b72321bb2f31d7f56261eefc8321"
+source = "git+https://github.com/jlest01/bitcoin_slices.git?branch=bip352-silentpayments-module-v0#ee774c189a78f05f9fea1bfe987f6696c9acfa39"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",
@@ -151,8 +149,7 @@ dependencies = [
 [[package]]
 name = "bitcoincore-rpc"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedd23ae0fd321affb4bbbc36126c6f49a32818dc6b979395d24da8c9d4e80ee"
+source = "git+https://github.com/jlest01/rust-bitcoincore-rpc.git?branch=bip352-silentpayments-module-v0#0a0db4394487caa15684fe82840d67da057b3565"
 dependencies = [
  "bitcoincore-rpc-json",
  "jsonrpc",
@@ -164,8 +161,7 @@ dependencies = [
 [[package]]
 name = "bitcoincore-rpc-json"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
+source = "git+https://github.com/jlest01/rust-bitcoincore-rpc.git?branch=bip352-silentpayments-module-v0#0a0db4394487caa15684fe82840d67da057b3565"
 dependencies = [
  "bitcoin",
  "serde",
@@ -180,9 +176,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -212,22 +208,23 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.15.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1521c5948ab432e084eabee0c9e4e965483f73156eaa0b04fc192e3f61205438"
+checksum = "c8cb1d556b8b8f36e5ca74938008be3ac102f5dcb5b68a0477e4249ae2291cd3"
 dependencies = [
  "serde",
- "toml 0.7.1",
+ "toml 0.8.19",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -253,9 +250,9 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clang-sys"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -276,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "configure_me_codegen"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2878e3458451e60138a59b3e19ffd00ae7df709a05aaac6aff3e87610ed3ea54"
+checksum = "d47e3f1ae619b1b7df4ed20a820a44c053e0b421e6d52f69d07320408568aab5"
 dependencies = [
  "cargo_toml",
  "fmt2io",
@@ -291,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -309,35 +306,28 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.16"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
-dependencies = [
- "cfg-if",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -382,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "electrs"
@@ -453,10 +443,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.8"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -464,15 +460,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fmt2io"
-version = "0.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9db8691f0820ad11ce6eb94057d0dd9c456500da04da0c12a85c90d6f979cc9"
+checksum = "6b6129284da9f7e5296cc22183a63f24300e945e297705dcc0672f7df01d62c8"
 
 [[package]]
 name = "fnv"
@@ -492,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -509,15 +505,15 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -527,9 +523,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
 dependencies = [
  "arrayvec",
 ]
@@ -554,47 +550,36 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
+name = "is-terminal"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix 0.38.31",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -613,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazycell"
@@ -625,36 +610,35 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.12"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
  "pkg-config",
@@ -663,21 +647,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -691,18 +669,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minimal-lexical"
@@ -712,9 +681,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minreq"
-version = "2.11.2"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fdef521c74c2884a4f3570bcdb6d2a77b3c533feb6b27ac2ae72673cc221c64"
+checksum = "763d142cdff44aaadd9268bebddb156ef6c65a0e13486bb81673cf2d8739f9b0"
 dependencies = [
  "log",
  "serde",
@@ -732,19 +701,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom8"
-version = "0.2.0"
+name = "once_cell"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
-]
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -752,15 +718,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -777,43 +743,56 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.71"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "procfs"
-version = "0.14.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de8dacb0873f77e6aefc6d71e044761fcc68060290f5b1089fcdf84626bb69"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.6.0",
  "hex",
  "lazy_static",
- "rustix 0.36.17",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.6.0",
+ "hex",
 ]
 
 [[package]]
 name = "prometheus"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -834,9 +813,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -893,18 +872,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
@@ -913,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.6"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -925,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.9"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -936,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rustc-hash"
@@ -948,36 +927,22 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.36.17"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
-dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.12",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scopeguard"
@@ -988,8 +953,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "secp256k1"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
+source = "git+https://github.com/rust-bitcoin/rust-secp256k1.git?rev=refs/pull/721/head#36b2c6bcf00b2add953916da128de272257d2ecc"
 dependencies = [
  "bitcoin_hashes",
  "rand",
@@ -1000,8 +964,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-sys"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
+source = "git+https://github.com/rust-bitcoin/rust-secp256k1.git?rev=refs/pull/721/head#36b2c6bcf00b2add953916da128de272257d2ecc"
 dependencies = [
  "cc",
 ]
@@ -1023,7 +986,7 @@ checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1039,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -1075,18 +1038,18 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "syn"
@@ -1101,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.42"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1112,14 +1075,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
- "rustix 0.38.31",
- "windows-sys 0.52.0",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1133,22 +1097,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.55"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.55"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1174,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.1"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772c1426ab886e7362aedf4abc9c0d1348a979517efedfc25862944d10137af0"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1186,24 +1150,24 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.1"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a238ee2e6ede22fb95350acc78e21dc40da00bb66c0334bde83de4ed89424e"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
  "indexmap",
- "nom8",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1220,9 +1184,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "vcpkg"
@@ -1232,9 +1196,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -1266,11 +1230,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1281,209 +1245,122 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
+name = "windows_i686_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
+name = "winnow"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.0"
+name = "zerocopy"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ spec = "internal/config_specification.toml"
 
 [dependencies]
 anyhow = "1.0"
-bitcoin = { version = "0.32.2", features = ["serde", "rand-std"] }
-bitcoin_slices = { version = "0.8", features = ["bitcoin", "sha2"] }
-bitcoincore-rpc = { version = "0.19.0" }
+bitcoin = { git = "https://github.com/jlest01/rust-bitcoin.git", branch = "bip352-silentpayments-module-v0", features = ["serde", "rand-std"] }
+bitcoin_slices = { git = "https://github.com/jlest01/bitcoin_slices.git", branch = "bip352-silentpayments-module-v0", features = ["bitcoin", "sha2"] }
+bitcoincore-rpc = {  git = "https://github.com/jlest01/rust-bitcoincore-rpc.git", branch = "bip352-silentpayments-module-v0" }
 configure_me = "0.4"
 crossbeam-channel = "0.5"
 dirs-next = "2.0"

--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -145,3 +145,7 @@ doc = "Logging filters, overriding `RUST_LOG` environment variable (see https://
 name = "signet_magic"
 type = "String"
 doc = "network magic for custom signet network in hex format, as found in Bitcoin Core logs (signet only)"
+
+[[switch]]
+name = "silent_payments_index"
+doc = "Enable silent payments index."

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.63.0"
+channel = "1.70.0"
 components = [ "rustfmt" ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,7 @@ pub struct Config {
     pub disable_electrum_rpc: bool,
     pub server_banner: String,
     pub signet_magic: Magic,
+    pub silent_payments_index: bool,
 }
 
 pub struct SensitiveAuth(pub Auth);
@@ -368,6 +369,7 @@ impl Config {
             disable_electrum_rpc: config.disable_electrum_rpc,
             server_banner: config.server_banner,
             signet_magic: magic,
+            silent_payments_index: config.silent_payments_index,
         };
         eprintln!(
             "Starting electrs {} on {} {} with {:?}",

--- a/src/db.rs
+++ b/src/db.rs
@@ -273,6 +273,16 @@ impl DBStore {
         self.iter_cf(self.headers_cf(), opts, None)
     }
 
+    pub(crate) fn read_tweaks(&self, height: u64) -> Vec<(Box<[u8]>, Box<[u8]>)> {
+        let mut opts = rocksdb::ReadOptions::default();
+        opts.set_iterate_lower_bound(height.to_be_bytes());
+        opts.fill_cache(false);
+        self.db
+            .iterator_cf_opt(self.tweak_cf(), opts, rocksdb::IteratorMode::Start)
+            .map(|row| row.expect("tweak iterator failed"))
+            .collect()
+    }
+
     pub(crate) fn get_tip(&self) -> Option<Vec<u8>> {
         self.db
             .get_cf(self.headers_cf(), TIP_KEY)

--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -529,7 +529,18 @@ impl Rpc {
             Err(response) => return response, // params parsing may fail - the response contains request id
         };
         self.rpc_duration.observe_duration(&call.method, || {
-            if self.tracker.status().is_err() {
+            let is_sp_indexing = self.tracker.silent_payments_index && self.tracker.sp_status().is_err();
+
+            if is_sp_indexing {
+                match &call.params {
+                    Params::SpTweaks(_) => {
+                        return error_msg(&call.id, RpcError::UnavailableIndex)
+                    }
+                    _ => (),
+                };
+            }
+
+            if is_sp_indexing || self.tracker.status().is_err() {
                 // Allow only a few RPC (for sync status notification) not requiring index DB being compacted.
                 match &call.params {
                     Params::BlockHeader(_)

--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -235,6 +235,10 @@ impl Rpc {
         Ok(json!({"count": count, "hex": String::from_iter(hex_headers), "max": max_count}))
     }
 
+    fn sp_tweaks(&self, (start_height,): (usize,)) -> Result<Value> {
+        Ok(json!(self.tracker.get_tweaks(start_height)?))
+    }
+
     fn estimate_fee(&self, (nblocks,): (u16,)) -> Result<Value> {
         Ok(self
             .daemon
@@ -554,6 +558,7 @@ impl Rpc {
                 Params::Banner => Ok(json!(self.banner)),
                 Params::BlockHeader(args) => self.block_header(*args),
                 Params::BlockHeaders(args) => self.block_headers(*args),
+                Params::SpTweaks(args) => self.sp_tweaks(*args),
                 Params::Donation => Ok(Value::Null),
                 Params::EstimateFee(args) => self.estimate_fee(*args),
                 Params::Features => self.features(),
@@ -583,6 +588,7 @@ enum Params {
     Banner,
     BlockHeader((usize,)),
     BlockHeaders((usize, usize)),
+    SpTweaks((usize,)),
     TransactionBroadcast((String,)),
     Donation,
     EstimateFee((u16,)),
@@ -608,6 +614,7 @@ impl Params {
         Ok(match method {
             "blockchain.block.header" => Params::BlockHeader(convert(params)?),
             "blockchain.block.headers" => Params::BlockHeaders(convert(params)?),
+            "blockchain.block.tweaks" => Params::SpTweaks(convert(params)?),
             "blockchain.estimatefee" => Params::EstimateFee(convert(params)?),
             "blockchain.headers.subscribe" => Params::HeadersSubscribe,
             "blockchain.relayfee" => Params::RelayFee,

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result};
 use bitcoin::consensus::{deserialize, Decodable, Encodable};
+use bitcoin::secp256k1::PublicKey;
 use bitcoin::hashes::Hash;
-use bitcoin::{BlockHash, OutPoint, Txid};
+use bitcoin::{BlockHash, OutPoint, Txid, XOnlyPublicKey};
 use bitcoin_slices::{bsl, Visit, Visitor};
+use std::collections::HashMap;
 use std::ops::ControlFlow;
 
 use crate::{
@@ -87,6 +89,7 @@ pub struct Index {
     chain: Chain,
     stats: Stats,
     is_ready: bool,
+    is_sp_ready: bool,
     flush_needed: bool,
 }
 
@@ -117,6 +120,7 @@ impl Index {
             chain,
             stats,
             is_ready: false,
+            is_sp_ready: false,
             flush_needed: false,
         })
     }
@@ -163,6 +167,65 @@ impl Index {
             .map(|row| HashPrefixRow::from_db_row(row).height())
             .filter_map(move |height| self.chain.get_block_hash(height))
     }
+    pub(crate) fn silent_payments_sync(
+        &mut self,
+        daemon: &Daemon,
+        exit_flag: &ExitFlag,
+    ) -> Result<bool> {
+
+        let mut new_headers: Vec<NewHeader> = Vec::with_capacity(2000);
+        let start: usize;
+        if let Some(row) = self.store.last_sp() {
+            let blockhash: BlockHash = deserialize(&row).expect("invalid block_hash");
+            start = self.chain.get_block_height(&blockhash).expect("Can't find block_hash") + 1;
+        } else {
+            start = 70_000;
+        }
+        let end = if start + 2000 < self.chain.height() {
+            start + 2000
+        } else {
+            self.chain.height()
+        };
+        for block_height in start..end {
+            new_headers.push(NewHeader::from((
+                *self
+                    .chain
+                    .get_block_header(block_height)
+                    .expect("Unexpected missing block header"),
+                block_height,
+            )));
+        }
+        match (new_headers.first(), new_headers.last()) {
+            (Some(first), Some(last)) => {
+                let count = new_headers.len();
+                info!(
+                    "Looking for sp tweaks in {} blocks: [{}..{}]",
+                    count,
+                    first.height(),
+                    last.height()
+                );
+            }
+            _ => {
+                if self.flush_needed {
+                    self.store.flush(); // full compaction is performed on the first flush call
+                    self.flush_needed = false;
+                }
+                self.is_sp_ready = true;
+                return Ok(true); // no more blocks to index (done for now)
+            }
+        }
+        for chunk in new_headers.chunks(self.batch_size) {
+            exit_flag.poll().with_context(|| {
+                format!(
+                    "indexing sp interrupted at height: {}",
+                    chunk.first().unwrap().height()
+                )
+            })?;
+            self.sync_blocks(daemon, chunk, true)?;
+        }
+        self.flush_needed = true;
+        Ok(false) // sync is not done
+    }
 
     // Return `Ok(true)` when the chain is fully synced and the index is compacted.
     pub(crate) fn sync(&mut self, daemon: &Daemon, exit_flag: &ExitFlag) -> Result<bool> {
@@ -195,7 +258,7 @@ impl Index {
                     chunk.first().unwrap().height()
                 )
             })?;
-            self.sync_blocks(daemon, chunk)?;
+            self.sync_blocks(daemon, chunk, false)?;
         }
         self.chain.update(new_headers);
         self.stats.observe_chain(&self.chain);
@@ -203,19 +266,39 @@ impl Index {
         Ok(false) // sync is not done
     }
 
-    fn sync_blocks(&mut self, daemon: &Daemon, chunk: &[NewHeader]) -> Result<()> {
+    fn sync_blocks(&mut self, daemon: &Daemon, chunk: &[NewHeader], sp: bool) -> Result<()> {
         let blockhashes: Vec<BlockHash> = chunk.iter().map(|h| h.hash()).collect();
         let mut heights = chunk.iter().map(|h| h.height());
 
         let mut batch = WriteBatch::default();
+        if !sp {
+            let scan_block = |blockhash, block| {
+                let height = heights.next().expect("unexpected block");
+                self.stats.observe_duration("block", || {
+                    index_single_block(blockhash, block, height, &mut batch);
+                });
+                self.stats.height.set("tip", height as f64);
+            };
 
-        daemon.for_blocks(blockhashes, |blockhash, block| {
-            let height = heights.next().expect("unexpected block");
-            self.stats.observe_duration("block", || {
-                index_single_block(blockhash, block, height, &mut batch);
-            });
-            self.stats.height.set("tip", height as f64);
-        })?;
+            daemon.for_blocks(blockhashes, scan_block)?;
+        } else {
+            let scan_block_for_sp = |blockhash, block| {
+                let height = heights.next().expect("unexpected block");
+                self.stats.observe_duration("block_sp", || {
+                    scan_single_block_for_silent_payments(
+                        self,
+                        daemon,
+                        blockhash,
+                        block,
+                        &mut batch,
+                    );
+                });
+                self.stats.height.set("sp", height as f64);
+            };
+
+            daemon.for_blocks(blockhashes, scan_block_for_sp)?;
+        }
+
         let heights: Vec<_> = heights.collect();
         assert!(
             heights.is_empty(),
@@ -224,14 +307,24 @@ impl Index {
         );
         batch.sort();
         self.stats.observe_batch(&batch);
-        self.stats
-            .observe_duration("write", || self.store.write(&batch));
+        if !sp {
+            self.stats
+                .observe_duration("write", || self.store.write(&batch));
+        } else {
+            self.stats
+                .observe_duration("write_sp", || self.store.write_sp(&batch));
+        }
+        
         self.stats.observe_db(&self.store);
         Ok(())
     }
 
     pub(crate) fn is_ready(&self) -> bool {
         self.is_ready
+    }
+
+    pub(crate) fn is_sp_ready(&self) -> bool {
+        self.is_sp_ready
     }
 }
 
@@ -290,6 +383,144 @@ fn index_single_block(
 
     let len = block_hash
         .consensus_encode(&mut (&mut batch.tip_row as &mut [u8]))
+        .expect("in-memory writers don't error");
+    debug_assert_eq!(len, BlockHash::LEN);
+}
+
+fn scan_single_block_for_silent_payments(
+    index: &Index,
+    daemon: &Daemon,
+    block_hash: BlockHash,
+    block: SerBlock,
+    batch: &mut WriteBatch,
+) {
+    struct IndexBlockVisitor<'a> {
+        daemon: &'a Daemon,
+        index: &'a Index,
+        map: &'a mut HashMap<BlockHash, Vec<u8>>,
+    }
+
+    impl<'a> Visitor for IndexBlockVisitor<'a> {
+        fn visit_transaction(&mut self, tx: &bsl::Transaction) -> core::ops::ControlFlow<()> {
+            let parsed_tx: bitcoin::Transaction = match deserialize(tx.as_ref()) {
+                Ok(tx) => tx,
+                Err(_) => panic!("Unexpected invalid transaction"),
+            };
+
+            if parsed_tx.is_coinbase() { return ControlFlow::Continue(()) };
+
+            let txid = bsl_txid(tx);
+
+            let mut to_scan = false;
+            for (i, o) in parsed_tx.output.iter().enumerate() {
+                if o.script_pubkey.is_p2tr() {
+                    let outpoint = OutPoint {
+                        txid,
+                        vout: i.try_into().expect("Unexpectedly high vout"),
+                    };
+                    if self
+                        .index
+                        .store
+                        .iter_spending(SpendingPrefixRow::scan_prefix(outpoint))
+                        .next()
+                        .is_none()
+                    {
+                        to_scan = true;
+                        break; // Stop iterating once a relevant P2TR output is found
+                    }
+                }
+            }
+
+            if !to_scan {
+                return ControlFlow::Continue(());
+            }
+
+            // Iterate over inputs
+            let mut pubkeys: Vec<PublicKey> = Vec::new();
+            let mut xonly_pubkeys: Vec<XOnlyPublicKey> = Vec::new();
+            let mut outpoints: Vec<(Txid, u32)> = Vec::with_capacity(parsed_tx.input.len());
+            for i in parsed_tx.input.iter() {
+                outpoints.push((i.previous_output.txid, i.previous_output.vout));
+                let prev_tx: bitcoin::Transaction = self
+                    .daemon
+                    .get_transaction(&i.previous_output.txid, None)
+                    .expect("Spending non existent UTXO");
+                let index: usize = i
+                    .previous_output
+                    .vout
+                    .try_into()
+                    .expect("Unexpectedly high vout");
+                let prevout: &bitcoin::TxOut = prev_tx
+                    .output
+                    .get(index)
+                    .expect("Spending a non existent UTXO");
+                match crate::sp::get_pubkey_from_input(&crate::sp::VinData {
+                    script_sig: i.script_sig.to_bytes(),
+                    txinwitness: i.witness.to_vec(),
+                    script_pub_key: prevout.script_pubkey.to_bytes(),
+                }) {
+                    Ok(Some(pubkey_from_input)) => match pubkey_from_input {
+                        crate::sp::PubKeyFromInput::XOnlyPublicKey(xonly_pubkey) => xonly_pubkeys.push(xonly_pubkey),
+                        crate::sp::PubKeyFromInput::PublicKey(pubkey) => pubkeys.push(pubkey), 
+                    },
+                    Ok(None) => (),
+                    Err(_) => panic!("Scanning for public keys failed for tx: {}", txid),
+                }
+            }
+            let pubkeys_ref: Vec<&PublicKey> = pubkeys.iter().collect();
+            let pubkeys_ref = pubkeys_ref.as_slice();
+
+            // if the pubkeys have opposite parity, the combine_pubkey_result will be Err
+            let combine_pubkey_result = PublicKey::combine_keys(pubkeys_ref);
+
+            if combine_pubkey_result.is_ok() && (!pubkeys.is_empty() || !xonly_pubkeys.is_empty()) {
+
+                let pubkeys_ref: Vec<&PublicKey> = pubkeys.iter().collect();
+                let input_pub_keys = if pubkeys.is_empty() {
+                    None
+                } else {
+                    Some(pubkeys_ref.as_slice())
+                }; 
+
+                let xonly_pubkeys_ref: Vec<&XOnlyPublicKey> = xonly_pubkeys.iter().collect();
+                let input_xpub_keys = if xonly_pubkeys.is_empty() {
+                    None
+                } else {
+                    Some(xonly_pubkeys_ref.as_slice())
+                }; 
+                
+                let tweak = crate::sp::recipient_calculate_tweak_data(input_xpub_keys, input_pub_keys, &outpoints).unwrap();
+
+                if let Some(block_hash) = self.index.filter_by_txid(txid).next() {
+                    if let Some(value) = self.map.get_mut(&block_hash) {
+                        value.extend(tweak.iter());
+                    } else {
+                        self.map.insert(block_hash, Vec::from_iter(tweak)); 
+                    }
+                } else {
+                    panic!("Unexpected unknown transaction");
+                }
+            }
+
+            ControlFlow::Continue(())
+        }
+    }
+
+    let mut map: HashMap<BlockHash, Vec<u8>> = HashMap::with_capacity(index.batch_size);
+    let mut index_block = IndexBlockVisitor {
+        daemon,
+        index,
+        map: &mut map
+    };
+    bsl::Block::visit(&block, &mut index_block).expect("core returned invalid block");
+    for (hash, tweaks) in map {
+        let height = index.chain.get_block_height(&hash).expect("Unexpected non existing blockhash");
+        let mut value: Vec<u8> = u64::try_from(height).expect("Unexpected invalid usize").to_be_bytes().to_vec();
+        value.extend(tweaks.iter());
+        batch.tweak_rows.push(value);
+    }
+    let len = block_hash
+        .consensus_encode(&mut (&mut batch.sp_tip_row as &mut [u8]))
         .expect("in-memory writers don't error");
     debug_assert_eq!(len, BlockHash::LEN);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod metrics;
 mod p2p;
 mod server;
 mod signals;
+mod sp;
 mod status;
 mod thread;
 mod tracker;

--- a/src/sp.rs
+++ b/src/sp.rs
@@ -1,0 +1,215 @@
+use bitcoin::{key::Secp256k1, secp256k1::{silentpayments::SilentpaymentsPublicData, PublicKey, XOnlyPublicKey}, Txid};
+use bitcoin_slices::bitcoin_hashes::{hash160, Hash};
+
+use anyhow::Error;
+
+// ** Putting all the pubkey extraction logic in the test utils for now. **
+// NUMS_H (defined in BIP340)
+const NUMS_H: [u8; 32] = [
+    0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9, 0x7a, 0x5e,
+    0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf, 0xee, 0x9a, 0xce, 0x80, 0x3a, 0xc0,
+];
+
+// Define OP_CODES used in script template matching for readability
+const OP_1: u8 = 0x51;
+const OP_0: u8 = 0x00;
+const OP_PUSHBYTES_20: u8 = 0x14;
+const OP_PUSHBYTES_32: u8 = 0x20;
+const OP_HASH160: u8 = 0xA9;
+const OP_EQUAL: u8 = 0x87;
+const OP_DUP: u8 = 0x76;
+const OP_EQUALVERIFY: u8 = 0x88;
+const OP_CHECKSIG: u8 = 0xAC;
+
+// Only compressed pubkeys are supported for silent payments
+const COMPRESSED_PUBKEY_SIZE: usize = 33;
+
+pub struct VinData {
+    pub script_sig: Vec<u8>,
+    pub txinwitness: Vec<Vec<u8>>,
+    pub script_pub_key: Vec<u8>,
+}
+
+// script templates for inputs allowed in BIP352 shared secret derivation
+pub fn is_p2tr(spk: &[u8]) -> bool {
+    matches!(spk, [OP_1, OP_PUSHBYTES_32, ..] if spk.len() == 34)
+}
+
+fn is_p2wpkh(spk: &[u8]) -> bool {
+    matches!(spk, [OP_0, OP_PUSHBYTES_20, ..] if spk.len() == 22)
+}
+
+fn is_p2sh(spk: &[u8]) -> bool {
+    matches!(spk, [OP_HASH160, OP_PUSHBYTES_20, .., OP_EQUAL] if spk.len() == 23)
+}
+
+fn is_p2pkh(spk: &[u8]) -> bool {
+    matches!(spk, [OP_DUP, OP_HASH160, OP_PUSHBYTES_20, .., OP_EQUALVERIFY, OP_CHECKSIG] if spk.len() == 25)
+}
+
+pub enum PubKeyFromInput {
+    XOnlyPublicKey(XOnlyPublicKey),
+    PublicKey(PublicKey),
+}
+
+pub fn get_pubkey_from_input(vin: &VinData) -> Result<Option<PubKeyFromInput>, Error> {
+    if is_p2pkh(&vin.script_pub_key) {
+        match (&vin.txinwitness.is_empty(), &vin.script_sig.is_empty()) {
+            (true, false) => {
+                let spk_hash = &vin.script_pub_key[3..23];
+                for i in (COMPRESSED_PUBKEY_SIZE..=vin.script_sig.len()).rev() {
+                    if let Some(pubkey_bytes) = &vin.script_sig.get(i - COMPRESSED_PUBKEY_SIZE..i) {
+                        let pubkey_hash = hash160::Hash::hash(pubkey_bytes);
+                        if pubkey_hash.to_byte_array() == spk_hash {
+                            let pubkey = PublicKey::from_slice(pubkey_bytes)?;
+                            let result = PubKeyFromInput::PublicKey(pubkey);
+                            return Ok(Some(result));
+                        }
+                    } else {
+                        return Ok(None);
+                    }
+                }
+            }
+            (_, true) => return Err(Error::msg("Empty script_sig for spending a p2pkh")),
+            (false, _) => return Err(Error::msg("non empty witness for spending a p2pkh")),
+        }
+    } else if is_p2sh(&vin.script_pub_key) {
+        match (&vin.txinwitness.is_empty(), &vin.script_sig.is_empty()) {
+            (false, false) => {
+                let redeem_script = &vin.script_sig[1..];
+                if is_p2wpkh(redeem_script) {
+                    if let Some(value) = vin.txinwitness.last() {
+                        if let Ok(pubkey) = PublicKey::from_slice(value) {
+                            let result = PubKeyFromInput::PublicKey(pubkey);
+                            return Ok(Some(result));
+                        } else {
+                            return Ok(None);
+                        }
+                    }
+                }
+            }
+            (_, true) => {
+                return Err(Error::msg(
+                    "Empty script_sig for spending a p2sh".to_owned(),
+                ))
+            }
+            (true, false) => {
+                return Ok(None);
+            }
+        }
+    } else if is_p2wpkh(&vin.script_pub_key) {
+        match (&vin.txinwitness.is_empty(), &vin.script_sig.is_empty()) {
+            (false, true) => {
+                if let Some(value) = vin.txinwitness.last() {
+                    if let Ok(pubkey) = PublicKey::from_slice(value) {
+                        let result = PubKeyFromInput::PublicKey(pubkey);
+                        return Ok(Some(result));
+                    } else {
+                        return Ok(None);
+                    }
+                } else {
+                    return Err(Error::msg("Empty witness".to_owned()));
+                }
+            }
+            (_, false) => {
+                return Err(Error::msg(
+                    "Non empty script sig for spending a segwit output".to_owned(),
+                ))
+            }
+            (true, _) => {
+                return Err(Error::msg(
+                    "Empty witness for spending a segwit output".to_owned(),
+                ))
+            }
+        }
+    } else if is_p2tr(&vin.script_pub_key) {
+        match (&vin.txinwitness.is_empty(), &vin.script_sig.is_empty()) {
+            (false, true) => {
+                // check for the optional annex
+                let annex = match vin.txinwitness.last().and_then(|value| value.get(0)) {
+                    Some(&0x50) => 1,
+                    Some(_) => 0,
+                    None => return Err(Error::msg("Empty or invalid witness".to_owned())),
+                };
+
+                // Check for script path
+                let stack_size = vin.txinwitness.len();
+                if stack_size > annex && vin.txinwitness[stack_size - annex - 1][1..33] == NUMS_H {
+                    return Ok(None);
+                }
+
+                // Return the pubkey from the script pubkey
+                return XOnlyPublicKey::from_slice(&vin.script_pub_key[2..34])
+                    .map_err(|e| Error::new(e))
+                    .map(|x_only_public_key| {
+                        let result = PubKeyFromInput::XOnlyPublicKey(x_only_public_key);
+                        Some(result)
+                    });
+            }
+            (_, false) => {
+                return Err(Error::msg(
+                    "Non empty script sig for spending a segwit output".to_owned(),
+                ))
+            }
+            (true, _) => {
+                return Err(Error::msg(
+                    "Empty witness for spending a segwit output".to_owned(),
+                ))
+            }
+        }
+    }
+    return Ok(None);
+}
+
+
+pub fn get_smallest_outpoint(outpoints_data: &[(Txid, u32)],) -> Result<[u8; 36], Error> {
+    if outpoints_data.is_empty() {
+        return Err(Error::msg("No outpoints provided"));
+    }
+
+    let mut outpoints: Vec<[u8; 36]> = Vec::with_capacity(outpoints_data.len());
+
+    for (txid, vout) in outpoints_data {
+        let bytes = bitcoin::consensus::encode::serialize(&txid);
+
+        if bytes.len() != 32 {
+            return Err(Error::msg(format!(
+                "Invalid outpoint hex representation: {}",
+                txid
+            )));
+        }
+
+        let mut buffer = [0u8; 36];
+
+        buffer[..32].copy_from_slice(&bytes);
+        buffer[32..].copy_from_slice(&vout.to_le_bytes());
+        outpoints.push(buffer);
+    }
+
+    // sort outpoints
+    outpoints.sort_unstable();
+
+    if let Some(smallest_outpoint) = outpoints.first() {
+        Ok(smallest_outpoint.clone())
+    } else {
+        // This should never happen
+        Err(Error::msg("Unexpected empty outpoints vector"))
+    }
+}
+
+pub fn recipient_calculate_tweak_data(
+    input_xpub_keys: Option<&[&XOnlyPublicKey]>,
+    input_pub_keys: Option<&[&PublicKey]>,
+    outpoints_data: &[(Txid, u32)],
+) -> Result<[u8; 33], Error> {
+    let smallest_outpoint = get_smallest_outpoint(outpoints_data).unwrap();
+    let secp = Secp256k1::new();
+    let public_data = SilentpaymentsPublicData::create(
+        &secp,
+        &smallest_outpoint,
+        input_xpub_keys,
+        input_pub_keys
+    ).unwrap();
+    let light_client_data33 = public_data.serialize(&secp).unwrap();
+    return Ok(light_client_data33);
+}

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -5,6 +5,7 @@ use bitcoin_slices::{
     Error::VisitBreak,
     Visit,
 };
+use std::collections::HashMap;
 
 use crate::{
     cache::Cache,
@@ -133,5 +134,14 @@ impl Tracker {
             };
         })?;
         Ok(result)
+    }
+
+    pub(crate) fn get_tweaks(&self, height: usize) -> Result<HashMap<u64, Vec<String>>> {
+        let tweaks: Vec<(u64, Vec<String>)> = self.index.get_tweaks(height as u64).collect();
+        let mut res: HashMap<u64, Vec<String>> = HashMap::new();
+        for (height, tweaks) in tweaks {
+            res.entry(height).or_insert_with(Vec::new).extend(tweaks)
+        }
+        Ok(res)
     }
 }

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -25,6 +25,7 @@ pub struct Tracker {
     mempool: Mempool,
     metrics: Metrics,
     ignore_mempool: bool,
+    silent_payments_index: bool,
 }
 
 pub(crate) enum Error {
@@ -52,6 +53,7 @@ impl Tracker {
             mempool: Mempool::new(&metrics),
             metrics,
             ignore_mempool: config.ignore_mempool,
+            silent_payments_index: config.silent_payments_index,
         })
     }
 


### PR DESCRIPTION
This PR proposes a new `--silent-payments-index` option that creates an index of Bip352 silent payments.
Most of the code is based on @Sosthene00's fork, but I made the following changes:

. It uses https://github.com/bitcoin-core/secp256k1/pull/1519 and https://github.com/rust-bitcoin/rust-secp256k1/pull/721 instead of the `rust-silentpayments` crate.
. It adds a new `--silent-payments-index` configuration option. Without this option, the server does not index silent payments and works the same as it does today.
. The code does not use `Box[u8]` in `db.rs`.

To run this, something like the following command can be used: `cargo run -- --log-filters=INFO --db-dir <db_dir> --daemon-dir ~/.bitcoin/ --network signet --electrum-rpc-addr="127.0.0.1:60001" --silent-payments-index`