### PR TITLE
feat: enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,6 @@ configure_me_codegen = { version = "0.4.8", default-features = false }
 bitcoin-test-data = "0.2.0"
 hex_lit = "0.1.1"
 tempfile = "3.13"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Resolves https://github.com/romanz/electrs/discussions/1092

Rebased on the latest `master`.

I have made several tests for the `cargo build --release` command.

Build time (a clean build) on my AMD Ryzen 9 5900x (Fedora 40):
* Release: 24s
* Full (Fat) LTO: 50s

The binary size:
* Release: 20 Mib
* Full (Fat) LTO: 16 Mib
