### PR TITLE
Implement ctrlc in place of signal hook on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,16 +10,19 @@ jobs:
   build:
     name: Build
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         build-args:
           [
             --locked --no-default-features,
-            --locked,
-            --locked --features metrics_process,
+            --locked
           ]
+        include:
+          - os: ubuntu-latest
+            build-args: --locked --features metrics_process
 
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,12 +351,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.2.5"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
 dependencies = [
  "nix",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -734,11 +734,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
+dependencies = [
+ "nix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +408,7 @@ dependencies = [
  "configure_me",
  "configure_me_codegen",
  "crossbeam-channel",
+ "ctrlc",
  "dirs-next",
  "electrs-rocksdb",
  "env_logger",
@@ -719,6 +730,17 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "1.0"
 tiny_http = { version = "0.12", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-ctrlc = "3.2.5"
+ctrlc = "=3.4.2" 
 
 [target.'cfg(not(windows))'.dependencies]
 signal-hook = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,13 @@ rayon = "1.9"
 serde = "1.0"
 serde_derive = "1.0, <=1.0.171"  # avoid precompiled binaries (https://github.com/serde-rs/serde/issues/2538)
 serde_json = "1.0"
-signal-hook = "0.3"
 tiny_http = { version = "0.12", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+ctrlc = "3.2.5"
+
+[target.'cfg(not(windows))'.dependencies]
+signal-hook = "0.3"
 
 [dependencies.electrs-rocksdb]
 version = "0.19.0-e3"

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -12,6 +12,7 @@ use std::sync::{
 };
 use std::{error, fmt};
 
+#[cfg(not(windows))]
 use crate::thread::spawn;
 
 #[derive(Debug)]

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,3 +1,4 @@
+#[cfg(not(windows))]
 use anyhow::Context;
 use crossbeam_channel::{unbounded, Receiver};
 #[cfg(not(windows))]


### PR DESCRIPTION
Satisfies #709, utilizing ctrlc in place of signal hook on Windows only.  