### PR TITLE
Run CI only on 'master' branch and PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,8 @@ name: electrs
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: "0 0 * * *" # once a day


### PR DESCRIPTION
To reduce redundant CI runs.