### PR TITLE
bump bitcoin slices dep 0.9.2 -> 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_slices"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2eede678354292a3e0c066e1c113f9868c705dfa8f91346d6b6f7c294205b0"
+checksum = "7943d4257fdfc85afe2a13d2b539a5213e97bb978329dd79b624acbce73042fb"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ spec = "internal/config_specification.toml"
 [dependencies]
 anyhow = "1.0"
 bitcoin = { version = "0.32.5", features = ["serde", "rand-std"] }
-bitcoin_slices = { version = "0.9", features = ["bitcoin", "sha2"] }
+bitcoin_slices = { version = "0.10.0", features = ["bitcoin", "sha2"] }
 bitcoincore-rpc = { version = "0.19.0" }
 configure_me = "0.4"
 crossbeam-channel = "0.5"


### PR DESCRIPTION
According to benchmark block parsing is up to 30% faster

https://github.com/RCasatta/bitcoin_slices/pull/44