### PR TITLE
fix: dead links in Rust source files

### DIFF
--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -354,7 +354,7 @@ impl Serialize for FeeHistogram {
         S: Serializer,
     {
         let mut seq = serializer.serialize_seq(Some(self.vsize.len()))?;
-        // https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html#mempool-get-fee-histogram
+        // https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#mempool-get-fee-histogram
         let fee_rates =
             (0..FeeHistogram::BINS).map(|i| u64::MAX.checked_shr(i as u32).unwrap_or(0));
         fee_rates

--- a/src/status.rs
+++ b/src/status.rs
@@ -52,8 +52,8 @@ impl TxEntry {
 }
 
 // Confirmation height of a transaction or its mempool state:
-// https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-history
-// https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-mempool
+// https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-history
+// https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-mempool
 enum Height {
     Confirmed { height: usize },
     Unconfirmed { has_unconfirmed_inputs: bool },
@@ -89,8 +89,8 @@ impl std::fmt::Display for Height {
 }
 
 // A single history entry:
-// https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-history
-// https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-mempool
+// https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-history
+// https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-mempool
 #[derive(Serialize)]
 pub(crate) struct HistoryEntry {
     #[serde(rename = "tx_hash")]
@@ -105,7 +105,7 @@ pub(crate) struct HistoryEntry {
 
 impl HistoryEntry {
     // Hash to compute ScriptHash status, as defined here:
-    // https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-basics.html#status
+    // https://electrum-protocol.readthedocs.io/en/latest/protocol-basics.html#status
     fn hash(&self, engine: &mut sha256::HashEngine) {
         let s = format!("{}:{}:", self.txid, self.height);
         engine.input(s.as_bytes());
@@ -141,7 +141,7 @@ pub struct ScriptHashStatus {
 }
 
 /// Specific scripthash balance
-/// https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-balance
+/// https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-balance
 #[derive(Default, Eq, PartialEq, Serialize)]
 pub(crate) struct Balance {
     #[serde(with = "bitcoin::amount::serde::as_sat", rename = "confirmed")]
@@ -151,7 +151,7 @@ pub(crate) struct Balance {
 }
 
 /// A single unspent transaction output entry
-/// https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-listunspent
+/// https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-listunspent
 #[derive(Serialize)]
 pub(crate) struct UnspentEntry {
     height: usize, // 0 = mempool entry
@@ -500,7 +500,7 @@ fn filter_inputs(tx: &Transaction, outpoints: &HashSet<OutPoint>) -> Vec<OutPoin
         .collect()
 }
 
-// See https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-basics.html#status for details
+// See https://electrum-protocol.readthedocs.io/en/latest/protocol-basics.html#status for details
 fn compute_status_hash(history: &[HistoryEntry]) -> Option<StatusHash> {
     if history.is_empty() {
         return None;

--- a/src/types.rs
+++ b/src/types.rs
@@ -75,7 +75,7 @@ impl HashPrefixRow {
 impl_consensus_encoding!(HashPrefixRow, prefix, height);
 
 hash_newtype! {
-    /// https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-basics.html#script-hashes
+    /// https://electrum-protocol.readthedocs.io/en/latest/protocol-basics.html#script-hashes
     #[hash_newtype(backward)]
     pub struct ScriptHash(sha256::Hash);
 }
@@ -110,7 +110,7 @@ impl ScriptHashRow {
 // ***************************************************************************
 
 hash_newtype! {
-    /// https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-basics.html#status
+    /// https://electrum-protocol.readthedocs.io/en/latest/protocol-basics.html#status
     pub struct StatusHash(sha256::Hash);
 }
 


### PR DESCRIPTION
Hi! I updated multiple outdated `electrumx-spesmilo` documentation links in `mempool.rs`, `status.rs`, and `types.rs`, replacing them with the correct `electrum-protocol` equivalents.

- **Replaced:** `electrumx-spesmilo.readthedocs.io` links with `electrum-protocol.readthedocs.io`
- **Files updated:**
  - `src/mempool.rs`
  - `src/status.rs`
  - `src/types.rs`