### PR TITLE
Fix grammar and wording issues in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,13 +27,13 @@ The codebase is maintained using the "contributor workflow" where everyone
 without exception contributes patch proposals using "pull requests". This
 facilitates social contribution, easy testing and peer review.
 
-To contribute a patch, the workflow is a as follows:
+To contribute a patch, the workflow is as follows:
 
 1. Fork repository
 2. Create topic branch
 3. Commit patches
 
-Please keep commits should atomic and diffs easy to read. For this reason
+Please keep commits atomic and diffs easy to read. For this reason
 do not mix any formatting fixes or code moves with actual code changes.
 Further, each commit, individually, should compile and pass tests, in order to
 ensure git bisect and other automated tools function properly.
@@ -84,7 +84,7 @@ grammar fixes.
 
 ### Formatting
 
-The repository currently does use `rustfmt` for all the formatting needs. Running the automated
+The repository currently uses `rustfmt` for all the formatting needs. Running the automated
 script mentioned above would format all your code for you :)
 
 ## Ending Notes

--- a/doc/cookie_deprecation.md
+++ b/doc/cookie_deprecation.md
@@ -21,7 +21,7 @@ The option was confusing:
 
 If you're installing `electrs` for the first time, just don't use `cookie`.
 If you're updating, reconsider the motivation above.
-If you used copying script, just use `cookie_file` to get the cookie directly.
+If you used a copying script, just use `cookie_file` to get the cookie directly.
 If you also used `BindsTo`, we recommend removing it.
 If you used fixed username and password because you didn't know about cookie or did it before `cookie_file` was implemented, reconsider using cookie authentication.
 If you really have to use fixed username and password, specify them using `auth` option (`username:password` like before) and remove the `cookie` option.


### PR DESCRIPTION
This PR fixes several grammatical issues in the documentation:

- Removes redundant "a" in "workflow is a as follows" in CONTRIBUTING.md
- Removes unnecessary "should" in commit instructions
- Changes "does use" to "uses" for better readability when describing rustfmt
- Adds missing article "a" in "used copying script" in cookie_deprecation.md

These changes improve the readability and correctness of the documentation without changing any technical content.