### PR TITLE
Fix broken Docker installation link in upgrading guide

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -38,7 +38,7 @@ Upgrading checklist:
 * If you use `verbose = 4` (or `-vvvv` argument) lower it down to `2` (`-vv`) for production use.
   Keeping it would waste resources because we utilize it more now.
 * **After reindexing**, if you did **not** delete `mainnet` subdirectory within `db_dir` check that `electrs` works as expected and then *delete whole `mainnet` subdirectory*.
-* If you are using our Dockerfile, please make sure to re-map the DB volume (see [the section above](docker.md#docker-based-installation-from-source)).
+* If you are using our Dockerfile, please make sure to re-map the DB volume (see [the section above](install.md#docker-based-installation-from-source)).
 
 ### Important changes from version older than 0.8.8
 


### PR DESCRIPTION
Replaced the outdated reference to docker.md with the correct link to the Docker installation section in install.md within the upgrading guide. This ensures users are directed to the proper instructions for Docker-based installation and configuration.