### PR TITLE
Fix broken ElectrumX protocol documentation link

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -102,7 +102,7 @@ $ echo '{"jsonrpc": "2.0", "method": "server.version", "params": ["", "1.4"], "i
 ```
 
 For more complex tasks, you may need to convert addresses to 
-[script hashes](https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-basics.html#script-hashes) - see 
+[script hashes](https://electrumx.readthedocs.io/en/latest/protocol-basics.html#script-hashes) - see 
 [contrib/history.py](https://github.com/romanz/electrs/blob/master/contrib/history.py) for getting an address balance and history:
 
 ```


### PR DESCRIPTION
Replaced the outdated and non-working link to the ElectrumX protocol "script hashes" documentation with the current, valid URL (https://electrumx.readthedocs.io/en/latest/protocol-basics.html#script-hashes) in doc/usage.md. This ensures users can access up-to-date protocol information without encountering a 404 error.