### PR TITLE
fix(run.sh): correct syntax for disabling strict mode in cleanup function

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6,7 +6,7 @@ mkdir -p data/{bitcoin,electrum,electrs}
 
 cleanup() {
   trap - SIGTERM SIGINT
-  set +eo pipefail
+  set +e +o pipefail
   jobs
   for j in `jobs -rp`
   do


### PR DESCRIPTION
The line
```
set +eo pipefail
```
was misspelled: Bash doesn't understand such a fused syntax.
The correct way to disable both modes is separately:
```
set +e — disables script termination on error (enabled by default via set -e).
set +o pipefail — disables script termination on pipe error (enabled by default via set -o pipefail).
```
Why is this important?
Strict mode is enabled at the beginning of the script:
```
set -euo pipefail
```
This means that the script will terminate immediately in case of any error.
But cleanup must correctly terminate all background processes, even if something has already gone wrong (for example, one of the processes has already been terminated and the kill command will generate an error).
If you leave it in strict mode, cleanup may abort on the first error and fail to terminate the rest of the processes.
Therefore:
In cleanup, we disable strict mode so that we can process all processes to completion, even if kill or wait gives an error.
This is what the line set +e +o pipefail is for.
