### PR TITLE
Update `cargo_toml` dependency and fix Dockerfile warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,12 +206,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.15.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1521c5948ab432e084eabee0c9e4e965483f73156eaa0b04fc192e3f61205438"
+checksum = "2bfbc36312494041e2cdd5f06697b7e89d4b76f42773a0b5556ac290ff22acc2"
 dependencies = [
  "serde",
- "toml 0.7.1",
+ "toml",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ dependencies = [
  "parse_arg",
  "serde",
  "serde_derive",
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -278,7 +278,7 @@ dependencies = [
  "fmt2io",
  "serde",
  "serde_derive",
- "toml 0.5.11",
+ "toml",
  "unicode-segmentation",
  "void",
 ]
@@ -525,12 +525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,16 +562,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
 
 [[package]]
 name = "is-terminal"
@@ -746,15 +730,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1070,15 +1045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,40 +1169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772c1426ab886e7362aedf4abc9c0d1348a979517efedfc25862944d10137af0"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a238ee2e6ede22fb95350acc78e21dc40da00bb66c0334bde83de4ed89424e"
-dependencies = [
- "indexmap",
- "nom8",
- "serde",
- "serde_spanned",
- "toml_datetime",
 ]
 
 [[package]]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,12 +2,12 @@
 # The maintainers of electrs are not deeply familiar with Docker, so you should DYOR.
 # If you are not familiar with Docker either it's probably be safer to NOT use it.
 
-FROM debian:bookworm-slim as base
+FROM debian:bookworm-slim AS base
 RUN apt-get update -qqy
 RUN apt-get install -qqy librocksdb-dev wget
 
 ### Electrum Rust Server ###
-FROM base as electrs-build
+FROM base AS electrs-build
 RUN apt-get install -qqy cargo clang cmake
 
 # Install electrs
@@ -18,7 +18,7 @@ ENV ROCKSDB_LIB_DIR=/usr/lib
 RUN cargo install --locked --path .
 
 ### Bitcoin Core ###
-FROM base as bitcoin-build
+FROM base AS bitcoin-build
 # Download
 WORKDIR /build/bitcoin
 ARG ARCH=x86_64
@@ -28,7 +28,7 @@ RUN tar xvf bitcoin-$BITCOIND_VERSION-$ARCH-linux-gnu.tar.gz
 RUN mv -v bitcoin-$BITCOIND_VERSION/bin/bitcoind .
 RUN mv -v bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli .
 
-FROM base as result
+FROM base AS result
 # Copy the binaries
 COPY --from=electrs-build /root/.cargo/bin/electrs /usr/bin/electrs
 COPY --from=bitcoin-build /build/bitcoin/bitcoind /build/bitcoin/bitcoin-cli /usr/bin/


### PR DESCRIPTION
```
warning: package `cargo_toml v0.15.0` in Cargo.lock is yanked in registry `crates-io`, consider updating to a version that is not yanked
```

https://crates.io/crates/cargo_toml/0.15.3 requires Rust 1.64, so let's downgrade to https://crates.io/crates/cargo_toml/0.14.1.