### PR TITLE
Add new test mempool accept method

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -173,6 +173,16 @@ impl Daemon {
             .context("failed to broadcast transaction")
     }
 
+    pub(crate) fn test_mempool_accept(&self, tx: &Transaction) -> Result<bool> {
+        Ok(self
+            .rpc
+            .test_mempool_accept(&[tx])
+            .context("failed to test mempool accept")?
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("failed to get mempool accept result"))?
+            .allowed)
+    }
+
     pub(crate) fn get_transaction_info(
         &self,
         txid: &Txid,

--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -365,6 +365,13 @@ impl Rpc {
         Ok(json!(txid))
     }
 
+    fn transaction_test_mempool_accept(&self, (tx_hex,): &(String,)) -> Result<Value> {
+        let tx_bytes = Vec::from_hex(tx_hex).context("non-hex transaction")?;
+        let tx = deserialize(&tx_bytes).context("invalid transaction")?;
+        let accepted = self.daemon.test_mempool_accept(&tx)?;
+        Ok(json!(accepted))
+    }
+
     fn transaction_get(&self, args: &TxGetArgs) -> Result<Value> {
         let (txid, verbose) = args.into();
         if verbose {
@@ -562,6 +569,9 @@ impl Rpc {
                 Params::ScriptHashSubscribe(args) => self.scripthash_subscribe(client, args),
                 Params::ScriptHashUnsubscribe(args) => self.scripthash_unsubscribe(client, args),
                 Params::TransactionBroadcast(args) => self.transaction_broadcast(args),
+                Params::TransactionTestMempoolAccept(args) => {
+                    self.transaction_test_mempool_accept(args)
+                }
                 Params::TransactionGet(args) => self.transaction_get(args),
                 Params::TransactionGetMerkle(args) => self.transaction_get_merkle(args),
                 Params::TransactionFromPosition(args) => self.transaction_from_pos(*args),
@@ -578,6 +588,7 @@ enum Params {
     BlockHeader((usize,)),
     BlockHeaders((usize, usize)),
     TransactionBroadcast((String,)),
+    TransactionTestMempoolAccept((String,)),
     Donation,
     EstimateFee((u16,)),
     Features,
@@ -611,6 +622,9 @@ impl Params {
             "blockchain.scripthash.subscribe" => Params::ScriptHashSubscribe(convert(params)?),
             "blockchain.scripthash.unsubscribe" => Params::ScriptHashUnsubscribe(convert(params)?),
             "blockchain.transaction.broadcast" => Params::TransactionBroadcast(convert(params)?),
+            "blockchain.transaction.testmempoolaccept" => {
+                Params::TransactionTestMempoolAccept(convert(params)?)
+            }
             "blockchain.transaction.get" => Params::TransactionGet(convert(params)?),
             "blockchain.transaction.get_merkle" => Params::TransactionGetMerkle(convert(params)?),
             "blockchain.transaction.id_from_pos" => {


### PR DESCRIPTION
This commits adds a new rpc method
(`blockchain.transaction.testmempoolaccept`) which proxies to Bitcoin'd [testmempoolaccept](https://developer.bitcoin.org/reference/rpc/testmempoolaccept.html)

---- 
Seeking a concept Ack/Nack here. My motivation for this PR comes from wanting to use Payjoin on wallets that use electrum as their primary block source. More info [here](https://github.com/orgs/payjoin/discussions/900). 

Usage example
```bash
printf '{"id": 1, "method": "blockchain.transaction.testmempoolaccept", "params": ["020000000001015ca6f32bfb04a38c4aae9537986bd9c813def7199c06a421dfdaec18d9bad2050100000000fdffffff02a08601000000000016001465982603ab037608de3e476f0840bf4989758ab34656f405000000002200203165bfb4cc98db8126d5a7fe8ed11428766a10ad2cec56a216567e82d36ac63002473044022012caf070e368b64657fea0456812abd833e0f6c27c0861a6df7964cd1e8d8b7502207d002fdadc60d9177d8ad7bdec3eb6a3222373cb5b18f63df5c32552b93cd529014421022c2b9f1a1bd2d6856c4a111913479b4d836f8f4d09fe953e0ffa806a86482721ac736476a914466f377a02381abaaef42e599229047a3336b02e88ad0374cd00b26859020000"]}\n' | nc 127.0.0.1 60401
```