### PR TITLE
Update `serde` to the latest version after the precompiled library got removed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,18 +1003,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ log = "0.4"
 parking_lot = "0.12"
 prometheus = { version = "0.13", optional = true }
 rayon = "1.11"
-serde = "1.0"
-serde_derive = "1.0, <=1.0.171"  # avoid precompiled binaries (https://github.com/serde-rs/serde/issues/2538)
+serde = "1.0.184"
+serde_derive = "1.0.184"
 serde_json = "1.0"
 tiny_http = { version = "0.12", optional = true }
 


### PR DESCRIPTION
I set it to 1.0.184 in Cargo.toml for the same reason it got done [here](https://github.com/RustCrypto/RSA/pull/360), Cargo will pull in the latest version actually (the now latest version 1.0.219 is semver-compatible with 1.0.184).

Serde's changelog mentions mostly bug fixes and binary size improvements, I only noticed a slight improvement in binary size (after this PR 99.97% of the size of before).