### PR TITLE
fix: outdated comment jsonrpc_timeout is for RPC calls, not wait_for_new_block

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -80,7 +80,7 @@ fn read_cookie(path: &Path) -> Result<(String, String)> {
 
 fn rpc_connect(config: &Config) -> Result<Client> {
     let rpc_url = format!("http://{}", config.daemon_rpc_addr);
-    // Allow `wait_for_new_block` to take a bit longer before timing out.
+    // Allow RPC calls to take longer before timing out.
     // See https://github.com/romanz/electrs/issues/495 for more details.
     let builder = jsonrpc::simple_http::SimpleHttpTransport::builder()
         .url(&rpc_url)?


### PR DESCRIPTION
The comment incorrectly referenced a non-existent function. The timeout
actually controls RPC call duration, while new block waiting is handled
via new_block_rx channel in server.rs.