### PR TITLE
Disable warning on `configure_me_config.rs`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
         run: cargo test  ${{ matrix.build-args }} --all
 
       - name: Clippy
-        run: cargo clippy -- -A unused-attributes -D warnings
+        run: cargo clippy -- -D warnings
 
   integration:
     name: Integration

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ pub const ELECTRS_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_SERVER_ADDRESS: [u8; 4] = [127, 0, 0, 1]; // by default, serve on IPv4 localhost
 
 mod internal {
-    #![allow(unused_imports)]
+    #![allow(unused_attributes, unused_imports)]
     include!(concat!(env!("OUT_DIR"), "/configure_me_config.rs"));
 }
 


### PR DESCRIPTION
```
warning: `#[automatically_derived]` attribute cannot be used on inherent impl blocks
   --> /home/user/src/electrs/target/release/build/electrs-cbf4110e4d56d95b/out/configure_me_config.rs:409:5
    |
409 |     #[automatically_derived]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
    = note: `#[warn(unused_attributes)]` (part of `#[warn(unused)]`) on by default

warning: `#[automatically_derived]` attribute cannot be used on inherent impl blocks
   --> /home/user/src/electrs/target/release/build/electrs-cbf4110e4d56d95b/out/configure_me_config.rs:886:1
    |
886 | #[automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[automatically_derived]` can only be applied to trait impl blocks

```