### PR TITLE
Update transaction.id_from_pos response for API compliance

### DIFF
--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -481,9 +481,9 @@ impl Rpc {
         let txid: Txid = txids[tx_pos];
         if merkle {
             let proof = Proof::create(&txids, tx_pos);
-            Ok(json!({"tx_id": txid, "merkle": proof.to_hex()}))
+            Ok(json!({"tx_hash": txid, "merkle": proof.to_hex()}))
         } else {
-            Ok(json!({ "tx_id": txid }))
+            Ok(json!({ "tx_hash": txid }))
         }
     }
 


### PR DESCRIPTION
While building a basic electrum api CLI and testing against my personal `electrs` node, I noticed an issue with `blockchain.transaction.id_from_pos`:

```bash
/target/debug/electrum-cli ssl://$SERVER_URL get-txid-from-pos 932452 1
Error: Made one or multiple attempts, all errored:
	- missing field `tx_hash`
```

I'm using the `rust-electrum-client` crate, which expects the JSON key for the TXID to be `tx_hash`, not `tx_id` as it is now:

https://docs.rs/electrum-client/latest/electrum_client/struct.TxidFromPosRes.html

So the deserialization of the response fails. According to the Electrum spec, the key should be `tx_hash`, not `tx_id`:

https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-transaction-id-from-pos

So the electrs implementation is the issue here IMO.

No test added since AFAICT this API isn't exposed via the `electrum` CLI tool, and I didn't see another suitable place to add one.

Great project btw - excited for the bindex work to get merged!