### PR TITLE
Fix build on GCC 15 (Fedora 43+) by injecting missing `<cstdint>` include

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# GCC 15 (Fedora 43+) no longer transitively includes <cstdint> from C++ headers.
+# The bundled RocksDB source in rust-librocksdb-sys requires uint64_t etc.,
+# so we inject the missing include globally for all C++ compilation units.
+[env]
+CXXFLAGS = "-include cstdint"


### PR DESCRIPTION
## Summary

- GCC 15 (shipped with Fedora 43+) no longer transitively includes `<cstdint>` from C++ standard headers
- This causes the bundled RocksDB source in `rust-librocksdb-sys` to fail with errors like `'uint64_t' has not been declared`
- Fix adds `.cargo/config.toml` that sets `CXXFLAGS = "-include cstdint"`, injecting the missing include globally for all C++ compilation units

## Why this approach

- No vendored source files are patched
- No impact on compilers that already include `<cstdint>` transitively (the flag is harmless if the header is already included)
- Minimal, single-file change

## Test plan

- [x] Clean `cargo build --release` succeeds on Fedora 43 with GCC 15
- [x] Resulting `electrs` binary runs and reports correct version (`v0.11.0`)