### PR TITLE
Use CDB for historic records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cdb64"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f12a8421b346e6f8d4af635b395e488c304a51f764aad8fe383f8aa98e7dfc3"
+dependencies = [
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +422,7 @@ dependencies = [
  "bitcoin-test-data",
  "bitcoin_slices",
  "bitcoincore-rpc",
+ "cdb64",
  "configure_me",
  "configure_me_codegen",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bitcoin", "electrum", "server", "index", "database"]
 documentation = "https://docs.rs/electrs/"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 build = "build.rs"
 
 [features]
@@ -23,6 +23,7 @@ spec = "internal/config_specification.toml"
 
 [dependencies]
 anyhow = "1.0"
+cdb64 = "0.2.0"
 bitcoin = { version = "0.32.8", features = ["serde", "rand-std"] }
 bitcoin_slices = { version = "0.10.0", features = ["bitcoin", "sha2"] }
 bitcoincore-rpc = { version = "0.19.0" }

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,7 +8,9 @@ RUN apt-get install -qqy librocksdb-dev wget
 
 ### Electrum Rust Server ###
 FROM base AS electrs-build
-RUN apt-get install -qqy cargo build-essential libclang-dev
+RUN apt-get install -qqy curl build-essential libclang-dev
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install electrs
 WORKDIR /build/electrs

--- a/doc/config_example.toml
+++ b/doc/config_example.toml
@@ -29,3 +29,6 @@ electrum_rpc_addr = "127.0.0.1:50001"
 
 # How much information about internal workings should electrs print. Increase before reporting a bug.
 log_filters = "INFO"
+
+# Directory to store CDB index files (optional).
+# cdb_dir = "/another/fast/storage/with/big/size"

--- a/doc/config_example.toml
+++ b/doc/config_example.toml
@@ -32,3 +32,6 @@ log_filters = "INFO"
 
 # Directory to store CDB index files (optional).
 # cdb_dir = "/another/fast/storage/with/big/size"
+
+# Maximum block height to store in CDB; blocks above this are stored in RocksDB (optional).
+# cdb_max_block_height = 900000

--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -156,3 +156,8 @@ doc = "network magic for custom network in hex format, as found in Bitcoin Core 
 name = "cdb_dir"
 type = "std::path::PathBuf"
 doc = "Directory to store CDB index files"
+
+[[param]]
+name = "cdb_max_block_height"
+type = "usize"
+doc = "Maximum block height to store in CDB (blocks above this height are stored in RocksDB)"

--- a/internal/config_specification.toml
+++ b/internal/config_specification.toml
@@ -151,3 +151,8 @@ doc = "Logging filters, overriding `RUST_LOG` environment variable (see https://
 name = "magic"
 type = "String"
 doc = "network magic for custom network in hex format, as found in Bitcoin Core logs"
+
+[[param]]
+name = "cdb_dir"
+type = "std::path::PathBuf"
+doc = "Directory to store CDB index files"

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,6 +147,7 @@ pub struct Config {
     pub server_banner: String,
     pub magic: Magic,
     pub cdb_path: Option<PathBuf>,
+    pub cdb_max_block_height: Option<usize>,
 }
 
 pub struct SensitiveAuth(pub Auth);
@@ -369,6 +370,7 @@ impl Config {
             server_banner: config.server_banner,
             magic,
             cdb_path,
+            cdb_max_block_height: config.cdb_max_block_height,
         };
         eprintln!(
             "Starting electrs {} on {} {} with {:?}",

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,7 @@ pub struct Config {
     pub disable_electrum_rpc: bool,
     pub server_banner: String,
     pub magic: Magic,
+    pub cdb_path: Option<PathBuf>,
 }
 
 pub struct SensitiveAuth(pub Auth);
@@ -207,6 +208,14 @@ impl Config {
         };
 
         config.db_dir.push(db_subdir);
+
+        let cdb_path = match config.cdb_dir {
+            Some(mut cdb_dir) => {
+                cdb_dir.push(db_subdir);
+                Some(cdb_dir)
+            }
+            _ => None,
+        };
 
         let default_daemon_rpc_port = match config.network {
             Network::Bitcoin => 8332,
@@ -359,6 +368,7 @@ impl Config {
             disable_electrum_rpc: config.disable_electrum_rpc,
             server_banner: config.server_banner,
             magic,
+            cdb_path,
         };
         eprintln!(
             "Starting electrs {} on {} {} with {:?}",

--- a/src/index.rs
+++ b/src/index.rs
@@ -245,6 +245,7 @@ impl Index {
         {
             if self.chain.height() >= cdb_max_height {
                 self.store.synchronize_cdb(cdb_path, cdb_max_height)?;
+                self.store.cleanup_rdb_duplications(cdb_max_height)?;
             }
         }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -12,10 +12,7 @@ use crate::{
     db::{DBStore, WriteBatch},
     metrics::{self, Gauge, Histogram, Metrics},
     signals::ExitFlag,
-    types::{
-        bsl_txid, HashPrefixRow, HeaderRow, ScriptHash, ScriptHashRow, SerBlock, SpendingPrefixRow,
-        TxidRow,
-    },
+    types::{bsl_txid, HeaderRow, ScriptHash, ScriptHashRow, SerBlock, SpendingPrefixRow, TxidRow},
 };
 
 #[derive(Clone)]
@@ -140,8 +137,7 @@ impl Index {
 
     pub(crate) fn filter_by_txid(&self, txid: Txid) -> impl Iterator<Item = BlockHash> + '_ {
         self.store
-            .iter_txid(TxidRow::scan_prefix(txid))
-            .map(|row| HashPrefixRow::from_db_row(row).height())
+            .iter_txid_block_heights(TxidRow::scan_prefix(txid))
             .filter_map(move |height| self.chain.get_block_hash(height))
     }
 
@@ -150,8 +146,7 @@ impl Index {
         scripthash: ScriptHash,
     ) -> impl Iterator<Item = BlockHash> + '_ {
         self.store
-            .iter_funding(ScriptHashRow::scan_prefix(scripthash))
-            .map(|row| HashPrefixRow::from_db_row(row).height())
+            .iter_funding_block_heights(ScriptHashRow::scan_prefix(scripthash))
             .filter_map(move |height| self.chain.get_block_hash(height))
     }
 
@@ -160,8 +155,7 @@ impl Index {
         outpoint: OutPoint,
     ) -> impl Iterator<Item = BlockHash> + '_ {
         self.store
-            .iter_spending(SpendingPrefixRow::scan_prefix(outpoint))
-            .map(|row| HashPrefixRow::from_db_row(row).height())
+            .iter_spending_block_heights(SpendingPrefixRow::scan_prefix(outpoint))
             .filter_map(move |height| self.chain.get_block_hash(height))
     }
 

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -91,6 +91,8 @@ impl Tracker {
                 config.index_batch_size,
                 config.index_lookup_limit,
                 config.reindex_last_blocks,
+                config.cdb_path.clone(),
+                config.cdb_max_block_height,
             )
             .context("failed to open index")?,
             mempool: Mempool::new(&metrics),

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -32,6 +32,10 @@ pub(crate) enum Error {
 
 impl Tracker {
     pub fn new(config: &Config, metrics: Metrics) -> Result<Self> {
+        if let Some(cdb_path) = &config.cdb_path {
+            std::fs::create_dir_all(cdb_path)
+                .with_context(|| format!("failed to create CDB directory {:?}", cdb_path))?;
+        }
         let store = DBStore::open(
             &config.db_path,
             config.db_log_dir.as_deref(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,7 @@ macro_rules! impl_consensus_encoding {
 }
 
 pub const HASH_PREFIX_LEN: usize = 8;
-const HEIGHT_SIZE: usize = 4;
+pub const HEIGHT_SIZE: usize = 4;
 
 pub(crate) type HashPrefix = [u8; HASH_PREFIX_LEN];
 pub(crate) type SerializedHashPrefixRow = [u8; HASH_PREFIX_ROW_SIZE];

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 rm -rf data/
-mkdir -p data/{bitcoin,electrum,electrs}
+mkdir -p data/{bitcoin,electrum,electrs,cdb}
 
 cleanup() {
   trap - SIGTERM SIGINT
@@ -52,6 +52,8 @@ export RUST_LOG=electrs=debug
 electrs \
   --db-dir=data/electrs \
   --daemon-dir=data/bitcoin \
+  --cdb-dir=data/cdb \
+  --cdb-max-block-height=80 \
   --network=regtest \
   2> data/electrs/regtest-debug.log &
 ELECTRS_PID=$!


### PR DESCRIPTION
RocksDB is a great key-value storage for mutable data, but most data in Bitcoin is immutable.
[CDB64](https://docs.rs/cdb64/latest/cdb64) is a very fast database for immutable data - using reference tables like this:

<img width="699" height="359" alt="image" src="https://github.com/user-attachments/assets/58d1e596-3f85-44c1-a92e-c7933e3f4e26" />

Originally CDB uses 32bits pointers, but cdb64 uses 64bits, source: https://www.unixuser.org/~euske/doc/cdbinternals/index.html.

Building the reference tables is a slow process, so the CDB can't replace RocksDB for fresh data. For example, we can store all the data up to block 900,000 in CDBs, and on query, search for it both in the CDB and the much-smaller RocksDB.

I haven't run benchmarks yet.