### PR TITLE
Fix `server.features` response format

### DIFF
--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -13,6 +13,7 @@ use serde_json::{self, json, Value};
 use std::collections::{hash_map::Entry, HashMap};
 use std::fmt;
 use std::iter::FromIterator;
+use std::net::SocketAddr;
 use std::str::FromStr;
 
 use crate::{
@@ -150,7 +151,7 @@ pub struct Rpc {
     daemon: Daemon,
     signal: Signal,
     banner: String,
-    port: u16,
+    addr: SocketAddr,
 }
 
 impl Rpc {
@@ -174,7 +175,7 @@ impl Rpc {
             daemon,
             signal,
             banner: config.server_banner.clone(),
-            port: config.electrum_rpc_addr.port(),
+            addr: config.electrum_rpc_addr,
         })
     }
 
@@ -507,7 +508,11 @@ impl Rpc {
     fn features(&self) -> Result<Value> {
         Ok(json!({
             "genesis_hash": self.tracker.chain().get_block_hash(0),
-            "hosts": { "tcp_port": self.port },
+            "hosts": {
+                self.addr.ip().to_string(): {
+                    "tcp_port": self.addr.port()
+                }
+            },
             "protocol_max": PROTOCOL_VERSION,
             "protocol_min": PROTOCOL_VERSION,
             "pruning": null,


### PR DESCRIPTION
The current `server.features` implementation returns an invalid `hosts` structure:

```json
"hosts": {"tcp_port": 50001}
```

According to the Electrum protocol, `hosts` must be a dictionary keyed by hostname, where each value is a dictionary containing optional keys such as `tcp_port` and/or `ssl_port`.

This change updates the response to the correct format, i.e.:

```json
{
    "genesis_hash": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
    "hosts": {
        "127.0.0.1": {
            "tcp_port": 50001
        },
    }
    "protocol_max": "1.4",
    "protocol_min": "1.4",
    "pruning": null,
    "server_version": "electrs/0.10.0",
    "hash_function": "sha256"
}
```

See: https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#server.features