### PR TITLE
Drop archived `bitcoincore-rpc` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,30 +149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoincore-rpc"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedd23ae0fd321affb4bbbc36126c6f49a32818dc6b979395d24da8c9d4e80ee"
-dependencies = [
- "bitcoincore-rpc-json",
- "jsonrpc",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "bitcoincore-rpc-json"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
-dependencies = [
- "bitcoin",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,7 +388,6 @@ dependencies = [
  "bitcoin",
  "bitcoin-test-data",
  "bitcoin_slices",
- "bitcoincore-rpc",
  "configure_me",
  "configure_me_codegen",
  "crossbeam-channel",
@@ -420,6 +395,7 @@ dependencies = [
  "dirs-next",
  "env_logger",
  "hex_lit",
+ "jsonrpc",
  "log",
  "parking_lot",
  "prometheus",
@@ -595,7 +571,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
 dependencies = [
  "base64",
- "minreq",
  "serde",
  "serde_json",
 ]
@@ -678,17 +653,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "minreq"
-version = "2.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d2aaba477837b46ec1289588180fabfccf0c3b1d1a0c6b1866240cd6cd5ce9"
-dependencies = [
- "log",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "nix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ spec = "internal/config_specification.toml"
 anyhow = "1.0"
 bitcoin = { version = "0.32.8", features = ["serde", "rand-std"] }
 bitcoin_slices = { version = "0.11.0", features = ["bitcoin", "sha2"] }
-bitcoincore-rpc = { version = "0.19.0" }
 configure_me = "0.4"
 crossbeam-channel = "0.5"
 dirs-next = "2.0"
 env_logger = "0.10"
+jsonrpc = "0.18"
 log = "0.4"
 parking_lot = "0.12"
 prometheus = { version = "0.14", optional = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
+use crate::rpc::Auth;
 use bitcoin::p2p::Magic;
 use bitcoin::Network;
-use bitcoincore_rpc::Auth;
 use dirs_next::home_dir;
 
 use std::ffi::{OsStr, OsString};

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3,7 +3,6 @@ use anyhow::{Context, Result};
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::{consensus::deserialize, hashes::hex::FromHex};
 use bitcoin::{Amount, BlockHash, Transaction, Txid};
-use bitcoincore_rpc::{json, jsonrpc, Auth, Client, RpcApi};
 use crossbeam_channel::Receiver;
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -18,6 +17,7 @@ use crate::{
     config::Config,
     metrics::Metrics,
     p2p::Connection,
+    rpc::{self, jsonrpc, Auth, Client},
     signals::ExitFlag,
     types::SerBlock,
 };
@@ -149,11 +149,7 @@ impl Daemon {
 
     pub(crate) fn estimate_fee(&self, nblocks: u16) -> Result<Option<Amount>> {
         let res = self.rpc.estimate_smart_fee(nblocks, None);
-        if let Err(bitcoincore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(RpcError {
-            code: -32603,
-            ..
-        }))) = res
-        {
+        if let Err(rpc::Error::JsonRpc(jsonrpc::Error::Rpc(RpcError { code: -32603, .. }))) = res {
             return Ok(None); // don't fail when fee estimation is disabled (e.g. with `-blocksonly=1`)
         }
         Ok(res.context("failed to estimate fee")?.fee_rate)
@@ -226,7 +222,7 @@ impl Daemon {
             .tx)
     }
 
-    pub(crate) fn get_mempool_info(&self) -> Result<json::GetMempoolInfoResult> {
+    pub(crate) fn get_mempool_info(&self) -> Result<rpc::GetMempoolInfoResult> {
         self.rpc
             .get_mempool_info()
             .context("failed to get mempool info")
@@ -241,11 +237,11 @@ impl Daemon {
     pub(crate) fn get_mempool_entries(
         &self,
         txids: &[Txid],
-    ) -> Result<Vec<Option<json::GetMempoolEntryResult>>> {
+    ) -> Result<Vec<Option<rpc::GetMempoolEntryResult>>> {
         let results = batch_request(self.rpc.get_jsonrpc_client(), "getmempoolentry", txids)?;
         Ok(results
             .into_iter()
-            .map(|r| match r?.result::<json::GetMempoolEntryResult>() {
+            .map(|r| match r?.result::<rpc::GetMempoolEntryResult>() {
                 Ok(entry) => Some(entry),
                 Err(err) => {
                     debug!("failed to get mempool entry: {}", err); // probably due to RBF
@@ -305,14 +301,11 @@ impl Daemon {
     }
 }
 
-pub(crate) type RpcError = bitcoincore_rpc::jsonrpc::error::RpcError;
+pub(crate) type RpcError = rpc::RpcError;
 
-pub(crate) fn extract_bitcoind_error(err: &bitcoincore_rpc::Error) -> Option<&RpcError> {
-    use bitcoincore_rpc::{
-        jsonrpc::error::Error::Rpc as ServerError, Error::JsonRpc as JsonRpcError,
-    };
+pub(crate) fn extract_bitcoind_error(err: &rpc::Error) -> Option<&RpcError> {
     match err {
-        JsonRpcError(ServerError(e)) => Some(e),
+        rpc::Error::JsonRpc(jsonrpc::Error::Rpc(e)) => Some(e),
         _ => None,
     }
 }

--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -718,7 +718,7 @@ impl Call {
             Err(err) => {
                 warn!("RPC {} failed: {:#}", self.method, err);
                 match err
-                    .downcast_ref::<bitcoincore_rpc::Error>()
+                    .downcast_ref::<crate::rpc::Error>()
                     .and_then(extract_bitcoind_error)
                 {
                     Some(e) => error_msg(&self.id, RpcError::DaemonError(e.clone())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod mempool;
 mod merkle;
 mod metrics;
 mod p2p;
+mod rpc;
 mod server;
 mod signals;
 mod status;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,0 +1,201 @@
+//! Minimal Bitcoin Core JSON-RPC client.
+//!
+//! Replaces the archived `bitcoincore-rpc` crate (see issue #1254). Implements only
+//! the subset of methods and response fields that electrs actually consumes, layered
+//! directly on top of the still-maintained `jsonrpc` crate.
+
+use std::fmt;
+use std::path::PathBuf;
+
+use bitcoin::consensus::encode::serialize_hex;
+use bitcoin::{Amount, BlockHash, Transaction, Txid};
+use serde_json::{json, value::to_raw_value, Value};
+
+pub use jsonrpc;
+pub use jsonrpc::error::RpcError;
+
+/// Error type returned by RPC calls.
+///
+/// Mirrors the two-layer shape callers used to pattern-match against on the old
+/// `bitcoincore_rpc::Error`: a JSON-RPC layer error or a local decode failure.
+#[derive(Debug)]
+pub enum Error {
+    JsonRpc(jsonrpc::Error),
+    /// Decoding hex- or consensus-encoded data returned by bitcoind failed.
+    Decode(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::JsonRpc(e) => write!(f, "JSON-RPC error: {}", e),
+            Error::Decode(msg) => write!(f, "failed to decode bitcoind response: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::JsonRpc(e) => Some(e),
+            Error::Decode(_) => None,
+        }
+    }
+}
+
+impl From<jsonrpc::Error> for Error {
+    fn from(e: jsonrpc::Error) -> Self {
+        Error::JsonRpc(e)
+    }
+}
+
+/// Result alias parallel to the old `bitcoincore_rpc::Result`.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Authentication mode for connecting to bitcoind's RPC endpoint.
+#[derive(Clone, Debug)]
+pub enum Auth {
+    /// No authentication. Kept for API completeness and matched by the connect path,
+    /// even though config.rs currently always populates one of the other variants.
+    #[allow(dead_code)]
+    None,
+    UserPass(String, String),
+    CookieFile(PathBuf),
+}
+
+/// Thin typed wrapper over [`jsonrpc::Client`] exposing the methods electrs uses.
+pub struct Client {
+    inner: jsonrpc::Client,
+}
+
+impl Client {
+    /// Wrap a pre-built `jsonrpc::Client` (so callers control the transport).
+    pub fn from_jsonrpc(inner: jsonrpc::Client) -> Self {
+        Self { inner }
+    }
+
+    /// Borrow the underlying `jsonrpc::Client` for batch requests.
+    pub fn get_jsonrpc_client(&self) -> &jsonrpc::Client {
+        &self.inner
+    }
+
+    /// Generic RPC call — serializes args to JSON and deserializes the response.
+    pub fn call<T>(&self, method: &str, args: &[Value]) -> Result<T>
+    where
+        T: for<'a> serde::de::Deserialize<'a>,
+    {
+        // `jsonrpc::Client::call` expects the whole params array packed into a single
+        // `RawValue`, not a slice of per-arg `RawValue`s.
+        let params = if args.is_empty() {
+            None
+        } else {
+            let array = Value::Array(args.to_vec());
+            Some(to_raw_value(&array).map_err(|e| Error::JsonRpc(jsonrpc::Error::Json(e)))?)
+        };
+        Ok(self.inner.call(method, params.as_deref())?)
+    }
+
+    pub fn get_network_info(&self) -> Result<GetNetworkInfoResult> {
+        self.call("getnetworkinfo", &[])
+    }
+
+    pub fn get_blockchain_info(&self) -> Result<GetBlockchainInfoResult> {
+        self.call("getblockchaininfo", &[])
+    }
+
+    pub fn estimate_smart_fee(
+        &self,
+        conf_target: u16,
+        estimate_mode: Option<&str>,
+    ) -> Result<EstimateSmartFeeResult> {
+        let mut args = vec![json!(conf_target)];
+        if let Some(mode) = estimate_mode {
+            args.push(json!(mode));
+        }
+        self.call("estimatesmartfee", &args)
+    }
+
+    pub fn send_raw_transaction(&self, tx: &Transaction) -> Result<Txid> {
+        self.call("sendrawtransaction", &[json!(serialize_hex(tx))])
+    }
+
+    pub fn get_raw_transaction(
+        &self,
+        txid: &Txid,
+        blockhash: Option<&BlockHash>,
+    ) -> Result<Transaction> {
+        let hex: String = self.call(
+            "getrawtransaction",
+            &[json!(txid), json!(false), json!(blockhash)],
+        )?;
+        let bytes = <Vec<u8> as bitcoin::hashes::hex::FromHex>::from_hex(&hex)
+            .map_err(|e| Error::Decode(format!("hex decode failed: {}", e)))?;
+        bitcoin::consensus::deserialize(&bytes)
+            .map_err(|e| Error::Decode(format!("transaction decode failed: {}", e)))
+    }
+
+    pub fn get_block_info(&self, blockhash: &BlockHash) -> Result<GetBlockResult> {
+        // Verbosity 1 = JSON with txids only (matches what electrs reads: .tx).
+        self.call("getblock", &[json!(blockhash), json!(1)])
+    }
+
+    pub fn get_mempool_info(&self) -> Result<GetMempoolInfoResult> {
+        self.call("getmempoolinfo", &[])
+    }
+
+    pub fn get_raw_mempool(&self) -> Result<Vec<Txid>> {
+        self.call("getrawmempool", &[])
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetNetworkInfoResult {
+    pub version: usize,
+    #[serde(rename = "networkactive")]
+    pub network_active: bool,
+    #[serde(rename = "relayfee", with = "bitcoin::amount::serde::as_btc")]
+    pub relay_fee: Amount,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetBlockchainInfoResult {
+    pub blocks: u64,
+    pub headers: u64,
+    pub pruned: bool,
+    #[serde(rename = "initialblockdownload")]
+    pub initial_block_download: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EstimateSmartFeeResult {
+    #[serde(
+        default,
+        rename = "feerate",
+        with = "bitcoin::amount::serde::as_btc::opt"
+    )]
+    pub fee_rate: Option<Amount>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetBlockResult {
+    pub tx: Vec<Txid>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetMempoolInfoResult {
+    /// Bitcoin Core 0.21+ field; older nodes omit it. Caller treats `None` as loaded.
+    pub loaded: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetMempoolEntryResult {
+    pub vsize: u64,
+    pub fees: GetMempoolEntryResultFees,
+    pub depends: Vec<Txid>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetMempoolEntryResultFees {
+    #[serde(with = "bitcoin::amount::serde::as_btc")]
+    pub base: Amount,
+}


### PR DESCRIPTION
Closes #1254.

The upstream `rust-bitcoincore-rpc` crate was [archived on 2025-11-25](https://github.com/rust-bitcoin/rust-bitcoincore-rpc/commit/92cad27319af78a77522090c4e1033ce7e738214). This PR removes it from electrs in favor of a small in-tree `rpc` module that calls bitcoind directly via the still-maintained `jsonrpc` crate (which electrs was already pulling in transitively and using directly in `batch_request`).

## Approach

I noticed `bitcoincore-rpc` was mostly a thin typed wrapper over `jsonrpc::Client`, and electrs uses only ~10 of its methods — so the replacement is narrow:

- **`Auth`** — local enum mirroring the three variants `config.rs` constructs.
- **`Client`** — wraps `jsonrpc::Client` and exposes the eight typed methods `Daemon` calls (`get_network_info`, `get_blockchain_info`, `estimate_smart_fee`, `send_raw_transaction`, `get_raw_transaction`, `get_block_info`, `get_mempool_info`, `get_raw_mempool`) plus the generic `call()` and `get_jsonrpc_client()` used for batch requests.
- **Response types** — `#[derive(Deserialize)]` structs containing **only the fields electrs actually reads**, matching the JSON-field renames bitcoind uses (`networkactive`, `initialblockdownload`, `relayfee`, `feerate`).
- **`Error`** — two-variant enum (`JsonRpc | Decode`) mirroring the nested shape callers already pattern-match against, so the changes in `daemon.rs` and `electrum.rs` are nearly mechanical.

## Diff

```
Cargo.lock      |  38 +-------- (bitcoincore-rpc + -rpc-json removed; no new deps)
Cargo.toml      |   2 +-        (drop bitcoincore-rpc, promote jsonrpc to direct)
src/config.rs   |   2 +-        (import swap)
src/daemon.rs   |  19 +++-----
src/electrum.rs |   2 +-        (downcast_ref target)
src/lib.rs      |   1 +         (mod rpc;)
src/rpc.rs      | 201 +++++++++ (new)
```

## Testing

- `cargo build --all-targets` — clean
- `cargo clippy --all-targets -- -D warnings` — zero warnings
- `cargo test --lib` — 21/21 pass (including `config::tests::test_auth_debug`, which exercises the local `Auth` enum's `Debug` formatting)
- **Integration smoke test** against Bitcoin Core 31 on regtest: drove every replaced RPC method end-to-end via the Electrum protocol:
  - `blockchain.relayfee` → `get_network_info::relay_fee` (BTC↔`Amount` serde)
  - `blockchain.estimatefee` → `estimate_smart_fee` (correctly maps missing `feerate` to `Option<Amount>::None` on regtest)
  - `blockchain.transaction.get` (hex) → `get_raw_transaction` (hex + consensus decode)
  - `blockchain.transaction.get` (verbose) → generic `Client::call`
  - `mempool.get_fee_histogram` → mempool sync exercising `get_mempool_info` + `get_raw_mempool` + batch `getmempoolentry` (incl. `fees.base`, `vsize`, `depends`) + batch `getrawtransaction`
  - `blockchain.transaction.broadcast` (fresh signed tx) → `send_raw_transaction`
  - error path: a deliberately-rejected rebroadcast returned through electrs as `{"code": 2, ...}`, confirming `extract_bitcoind_error` and the `downcast_ref::<crate::rpc::Error>()` in `electrum.rs` work as before.
- Implicitly exercised at startup: `get_blockchain_info` (`rpc_poll`), `get_block_info` (indexing 111 blocks), `get_mempool_info`.

## Notes

- I left `Auth::None` in place (marked `#[allow(dead_code)]`) for API completeness — `daemon.rs` matches it but no current code path constructs it. Easy to remove if you'd prefer.
- I deliberately did **not** add an `EstimateMode` enum (the old `bitcoincore_rpc_json::EstimateMode`) since electrs always passes `None` for it. The new `estimate_smart_fee` takes `Option<&str>` instead, which avoids dead variants. Happy to add the enum back if you'd rather keep the API surface.
- I'm aware of #1252 (`bindex`) — if that's expected to land soon and will rewrite most of `daemon.rs` anyway, this PR could be deferred or closed. It's a tidy interim cleanup either way.