### PR TITLE
doc: clarify why Tor connections use plain TCP on port 50001

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -78,7 +78,7 @@ Please read upgrade notes if you're upgrading to a newer version.
 
 To connect to your Electrs server, you will need to point Electrum to your server using the `ip_address:port` syntax. You will notice that most default servers in Electrum use the `50002` port (which is for SSL connections), while Electrs serves port `50001` and does not provide SSL out of the box.
 
-You would need to either use a webserver to provide SSL (see _SSL connection_ below), or connect without SSL. To tell Electrum to connect to your server without SSL, you need to add `:t` after the port (ie: `localhost:50001:t`). Please note that this is not secure and therefore recommended only for local connections.
+You would need to either use a webserver to provide SSL (see _SSL connection_ below), or connect without SSL. To tell Electrum to connect to your server without SSL, you need to add `:t` after the port (ie: `localhost:50001:t`). Plain TCP is unauthenticated and unencrypted, so it should only be used for local connections or when reaching the server through a Tor hidden service (see [_Tor hidden service_](#tor-hidden-service) below).
 
 Electrs will listen by default on `127.0.0.1:50001`, which means it will only serve clients in the local machine. This is configured via the `electrum_rpc_addr` setting and if you wish to connect from another machine, you need to change it to `0.0.0.0:50001`. This is less secure though, and the recommended way to access Electrs remotely is to keep listening on `127.0.0.1` and tunnel to your server.
 
@@ -153,10 +153,12 @@ $ sudo cat /var/lib/tor/electrs_hidden_service/hostname
 <your-onion-address>.onion
 ```
 
-On your client machine, run the following command (assuming Tor proxy service runs on port 9050):
+On your client machine, run the following command (assuming Tor proxy service runs on port 9050 — use port `9150` instead if you are proxying through a running Tor Browser bundle):
 ```
 $ electrum --oneserver --server <your-onion-address>.onion:50001:t --proxy socks5:127.0.0.1:9050
 ```
+
+The `:t` suffix tells Electrum to connect over plain TCP (no TLS). The example uses port `50001` rather than `50002` because `electrs` does not provide TLS itself; the SSL setup above is only needed for non-Tor connections. TLS is generally unnecessary when reaching `electrs` through an `.onion` address: the v3 onion address encodes the hidden service's Ed25519 public key, and the Tor rendezvous handshake provides end-to-end authentication and encryption between client and server. Layering TLS on top is still possible if a client requires it — use the [SSL terminator setup](#ssl-connection) above and connect with `<your-onion-address>.onion:50002:s` — but it is not required.
 
 For more details, see http://docs.electrum.org/en/latest/tor.html.
 


### PR DESCRIPTION
Closes #1144.

[#1144](https://github.com/romanz/electrs/issues/1144) reports a confusion: this repository's `doc/config.md` Tor section instructs users to connect with `<onion>.onion:50001:t` over SOCKS `9050`, while external guides such as raspiblitz's terminal UI document the connection as `<onion>.onion:50002:s` over SOCKS `9150`. The user asked which is correct.

## The answer

`doc/config.md` is correct as written:

- `electrs` has no native TLS support (verified: no `rustls`/`openssl`/TLS-related dependency in `Cargo.toml`, and `src/server.rs` only emits a warning when a client tries to connect with SSL). Port `50002` with the `:s` suffix only works if an external TLS terminator like nginx/stunnel sits in front, which the SSL-connection section already covers.
- TLS is not required when reaching `electrs` through an `.onion` address: the v3 onion address encodes the hidden service's Ed25519 public key, and the Tor rendezvous handshake provides end-to-end authentication and encryption between client and server.
- Port `9050` is the standalone `tor` daemon's SOCKS port. Port `9150` is the Tor Browser bundle's SOCKS — that's the one the raspiblitz example uses, because raspiblitz users may be proxying through Tor Browser.

So the contradiction is *not* in the technical advice — it is in the doc not *explaining* its choice, and in one earlier sentence flatly stating that plain TCP is "recommended only for local connections", which contradicts the Tor section that follows.

## What this PR changes

`doc/config.md` only — a +4/-2 prose adjustment:

1. **"Connecting an Electrum client" section.** Softens the existing "recommended only for local connections" to also acknowledge Tor hidden services as a safe context for plain TCP, with a forward link to the Tor section.
2. **"Tor hidden service" section.** Adds one paragraph explaining why port `50001` + `:t` is correct (no native TLS in `electrs`), why TLS is generally unnecessary over an `.onion` endpoint (with a brief, correct one-liner on the v3 onion ↔ Ed25519 public-key relationship), and how to layer TLS on top *anyway* if a client requires it — by referring to the SSL terminator setup already documented above.
3. **SOCKS port note.** Mentions `9150` for users proxying through the Tor Browser bundle, in addition to the existing `9050` for the standalone `tor` daemon.

## Why this is the right scope

I deliberately kept this to docs-only and minimal. Two alternatives I considered and rejected:

- **Add native TLS support to `electrs`** so the `:s` form Just Works. Out of scope for #1144, and adds significant new dependency surface (rustls/openssl).
- **Add a new `doc/tor.md` standalone guide.** Heavier than the issue calls for and would duplicate parts of `doc/config.md`. The existing structure already has a Tor section; the right fix is to make it self-explanatory.

## Verification

- `cargo build` — clean (defensive; no code changed).
- Anchor targets `#tor-hidden-service` and `#ssl-connection` both resolve to existing `### …` headers in the file.
- The diff is +4 / -2 lines, all prose.