### PR TITLE
Add optional `mode` argument to `blockchain.estimatefee`

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::{consensus::deserialize, hashes::hex::FromHex};
 use bitcoin::{Amount, BlockHash, Transaction, Txid};
-use bitcoincore_rpc::{json, jsonrpc, Auth, Client, RpcApi};
+use bitcoincore_rpc::{json, json::EstimateMode, jsonrpc, Auth, Client, RpcApi};
 use crossbeam_channel::Receiver;
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -147,8 +147,12 @@ impl Daemon {
         Ok(Self { p2p, rpc })
     }
 
-    pub(crate) fn estimate_fee(&self, nblocks: u16) -> Result<Option<Amount>> {
-        let res = self.rpc.estimate_smart_fee(nblocks, None);
+    pub(crate) fn estimate_fee(
+        &self,
+        nblocks: u16,
+        mode: Option<EstimateMode>,
+    ) -> Result<Option<Amount>> {
+        let res = self.rpc.estimate_smart_fee(nblocks, mode);
         if let Err(bitcoincore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(RpcError {
             code: -32603,
             ..

--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -5,6 +5,7 @@ use bitcoin::{
     hex::DisplayHex,
     BlockHash, Transaction, Txid,
 };
+use bitcoincore_rpc::json::EstimateMode;
 use crossbeam_channel::Receiver;
 use rayon::prelude::*;
 use serde_derive::Deserialize;
@@ -98,6 +99,28 @@ impl BroadcastArgs {
         match self {
             BroadcastArgs::Package(_) => false,
             BroadcastArgs::PackageVerbose((_, verbose)) => *verbose,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum EstimateFeeArgs {
+    NoMode((u16,)),
+    WithMode((u16, String)),
+}
+
+impl EstimateFeeArgs {
+    fn nblocks(&self) -> u16 {
+        match self {
+            Self::NoMode((n,)) | Self::WithMode((n, _)) => *n,
+        }
+    }
+
+    fn mode(&self) -> Option<&str> {
+        match self {
+            Self::NoMode(_) => None,
+            Self::WithMode((_, m)) => Some(m),
         }
     }
 }
@@ -260,10 +283,11 @@ impl Rpc {
         Ok(json!({"count": count, "hex": String::from_iter(hex_headers), "max": max_count}))
     }
 
-    fn estimate_fee(&self, (nblocks,): (u16,)) -> Result<Value> {
+    fn estimate_fee(&self, args: &EstimateFeeArgs) -> Result<Value> {
+        let mode = args.mode().map(parse_estimate_mode).transpose()?;
         Ok(self
             .daemon
-            .estimate_fee(nblocks)?
+            .estimate_fee(args.nblocks(), mode)?
             .map(|fee_rate| json!(fee_rate.to_btc()))
             .unwrap_or_else(|| json!(UNKNOWN_FEE)))
     }
@@ -605,7 +629,7 @@ impl Rpc {
                 Params::BlockHeader(args) => self.block_header(*args),
                 Params::BlockHeaders(args) => self.block_headers(*args),
                 Params::Donation => Ok(Value::Null),
-                Params::EstimateFee(args) => self.estimate_fee(*args),
+                Params::EstimateFee(args) => self.estimate_fee(args),
                 Params::Features => self.features(),
                 Params::HeadersSubscribe => self.headers_subscribe(client),
                 Params::MempoolFeeHistogram => self.get_fee_histogram(),
@@ -639,7 +663,7 @@ enum Params {
     TransactionBroadcast((String,)),
     TransactionBroadcastPackage(BroadcastArgs),
     Donation,
-    EstimateFee((u16,)),
+    EstimateFee(EstimateFeeArgs),
     Features,
     HeadersSubscribe,
     MempoolFeeHistogram,
@@ -832,6 +856,20 @@ fn tx_from_hex(tx_hex: &str) -> Result<Transaction> {
     Ok(tx)
 }
 
+/// Parse the `mode` string for `blockchain.estimatefee` into bitcoind's `EstimateMode`.
+/// Accepted values (case-insensitive): `UNSET`, `ECONOMICAL`, `CONSERVATIVE`.
+fn parse_estimate_mode(s: &str) -> Result<EstimateMode> {
+    match s.to_ascii_uppercase().as_str() {
+        "UNSET" => Ok(EstimateMode::Unset),
+        "ECONOMICAL" => Ok(EstimateMode::Economical),
+        "CONSERVATIVE" => Ok(EstimateMode::Conservative),
+        _ => bail!(
+            "invalid estimatefee mode {:?}; expected ECONOMICAL, CONSERVATIVE, or UNSET",
+            s
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -843,6 +881,54 @@ mod tests {
         assert_eq!(parse_version("1.2.345").unwrap(), Version(vec![1, 2, 345]));
 
         assert!(parse_version("1.2").unwrap() < parse_version("1.100").unwrap());
+    }
+
+    #[test]
+    fn test_parse_estimate_mode_known_values() {
+        assert_eq!(parse_estimate_mode("UNSET").unwrap(), EstimateMode::Unset);
+        assert_eq!(
+            parse_estimate_mode("ECONOMICAL").unwrap(),
+            EstimateMode::Economical
+        );
+        assert_eq!(
+            parse_estimate_mode("CONSERVATIVE").unwrap(),
+            EstimateMode::Conservative
+        );
+    }
+
+    #[test]
+    fn test_parse_estimate_mode_case_insensitive() {
+        assert_eq!(
+            parse_estimate_mode("economical").unwrap(),
+            EstimateMode::Economical
+        );
+        assert_eq!(
+            parse_estimate_mode("Conservative").unwrap(),
+            EstimateMode::Conservative
+        );
+    }
+
+    #[test]
+    fn test_parse_estimate_mode_rejects_invalid() {
+        let err = parse_estimate_mode("turbo").unwrap_err().to_string();
+        assert!(
+            err.contains("turbo"),
+            "error should mention bad value: {err}"
+        );
+    }
+
+    #[test]
+    fn test_estimate_fee_args_no_mode() {
+        let args: EstimateFeeArgs = serde_json::from_str("[6]").unwrap();
+        assert_eq!(args.nblocks(), 6);
+        assert_eq!(args.mode(), None);
+    }
+
+    #[test]
+    fn test_estimate_fee_args_with_mode() {
+        let args: EstimateFeeArgs = serde_json::from_str(r#"[6, "ECONOMICAL"]"#).unwrap();
+        assert_eq!(args.nblocks(), 6);
+        assert_eq!(args.mode(), Some("ECONOMICAL"));
     }
 
     #[test]


### PR DESCRIPTION
Refs #1241 — checks off the `blockchain.estimatefee` mode item on the v1.6 protocol checklist.

## Summary

Electrum protocol v1.6 adds an optional second `mode` argument to [`blockchain.estimatefee`](https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-estimatefee) that is forwarded to bitcoind's [`estimatesmartfee`](https://developer.bitcoin.org/reference/rpc/estimatesmartfee.html) as `estimate_mode`.

- Accepted values (case-insensitive): `UNSET`, `ECONOMICAL`, `CONSERVATIVE`
- **Backwards-compatible**: existing 1-arg calls `[nblocks]` keep working — handled via an `#[serde(untagged)]` enum that accepts either form (same pattern as `BroadcastArgs`).
- Invalid mode strings produce a JSON-RPC error rather than being silently forwarded to bitcoind.

The string→enum parsing (`parse_estimate_mode`) is a free function so it can be unit-tested without an RPC client.

## Test plan

- [x] 5 new unit tests in `electrum::tests`: known values, case-insensitivity, invalid value rejection, 1-arg deserialization, 2-arg deserialization
- [x] `cargo test --lib` — 26/26 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Live tested against Bitcoin Core v31.0.0 on regtest covering all paths:

```
$ printf '{"id":0,"method":"server.version","params":["test","1.4"]}
{"id":1,"method":"blockchain.estimatefee","params":[6]}
{"id":2,"method":"blockchain.estimatefee","params":[6,"ECONOMICAL"]}
{"id":3,"method":"blockchain.estimatefee","params":[6,"conservative"]}
{"id":4,"method":"blockchain.estimatefee","params":[6,"turbo"]}
' | nc -w 3 127.0.0.1 60401

{"id":0,"jsonrpc":"2.0","result":["electrs/0.11.1","1.4"]}
{"id":1,"jsonrpc":"2.0","result":-1}
{"id":2,"jsonrpc":"2.0","result":-1}
{"id":3,"jsonrpc":"2.0","result":-1}
{"error":{"code":1,"message":"invalid estimatefee mode \"turbo\"; expected ECONOMICAL, CONSERVATIVE, or UNSET"},"id":4,"jsonrpc":"2.0"}
```

The `-1` return values are the expected `UNKNOWN_FEE` because regtest has no fee history — the point of the demo is showing that all four dispatch paths (1-arg, 2-arg with each mode, invalid mode) behave correctly.