### PR TITLE
Implement `blockchain.scripthash.get_mempool` Electrum RPC method

### DIFF
--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -308,6 +308,28 @@ impl Rpc {
         Ok(history_entries)
     }
 
+    fn scripthash_get_mempool(
+        &self,
+        client: &Client,
+        (scripthash,): &(ScriptHash,),
+    ) -> Result<Value> {
+        // https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-mempool
+        let mempool_entries = match client.scripthashes.get(scripthash) {
+            Some(status) => json!(status.get_mempool().collect::<Vec<_>>()),
+            None => {
+                info!(
+                    "{} blockchain.scripthash.get_mempool called for unsubscribed scripthash",
+                    UNSUBSCRIBED_QUERY_MESSAGE
+                );
+                json!(self
+                    .new_status(*scripthash)?
+                    .get_mempool()
+                    .collect::<Vec<_>>())
+            }
+        };
+        Ok(mempool_entries)
+    }
+
     fn scripthash_list_unspent(
         &self,
         client: &Client,
@@ -614,6 +636,7 @@ impl Rpc {
                 Params::RelayFee => self.relayfee(),
                 Params::ScriptHashGetBalance(args) => self.scripthash_get_balance(client, args),
                 Params::ScriptHashGetHistory(args) => self.scripthash_get_history(client, args),
+                Params::ScriptHashGetMempool(args) => self.scripthash_get_mempool(client, args),
                 Params::ScriptHashListUnspent(args) => self.scripthash_list_unspent(client, args),
                 Params::ScriptHashSubscribe(args) => self.scripthash_subscribe(client, args),
                 Params::ScriptHashUnsubscribe(args) => self.scripthash_unsubscribe(client, args),
@@ -648,6 +671,7 @@ enum Params {
     RelayFee,
     ScriptHashGetBalance((ScriptHash,)),
     ScriptHashGetHistory((ScriptHash,)),
+    ScriptHashGetMempool((ScriptHash,)),
     ScriptHashListUnspent((ScriptHash,)),
     ScriptHashSubscribe((ScriptHash,)),
     ScriptHashUnsubscribe((ScriptHash,)),
@@ -667,6 +691,7 @@ impl Params {
             "blockchain.relayfee" => Params::RelayFee,
             "blockchain.scripthash.get_balance" => Params::ScriptHashGetBalance(convert(params)?),
             "blockchain.scripthash.get_history" => Params::ScriptHashGetHistory(convert(params)?),
+            "blockchain.scripthash.get_mempool" => Params::ScriptHashGetMempool(convert(params)?),
             "blockchain.scripthash.listunspent" => Params::ScriptHashListUnspent(convert(params)?),
             "blockchain.scripthash.subscribe" => Params::ScriptHashSubscribe(convert(params)?),
             "blockchain.scripthash.unsubscribe" => Params::ScriptHashUnsubscribe(convert(params)?),

--- a/src/status.rs
+++ b/src/status.rs
@@ -111,6 +111,11 @@ impl HistoryEntry {
         engine.input(s.as_bytes());
     }
 
+    /// True when this entry refers to a mempool (unconfirmed) transaction.
+    pub(crate) fn is_unconfirmed(&self) -> bool {
+        matches!(self.height, Height::Unconfirmed { .. })
+    }
+
     fn confirmed(txid: Txid, height: usize) -> Self {
         Self {
             txid,
@@ -282,6 +287,12 @@ impl ScriptHashStatus {
     /// Collect transaction history entries
     pub(crate) fn get_history(&self) -> &[HistoryEntry] {
         &self.history
+    }
+
+    /// Collect mempool history entries (subset of `get_history`).
+    /// Order matches the status-hash calculation, as required by Electrum protocol v1.6.
+    pub(crate) fn get_mempool(&self) -> impl Iterator<Item = &HistoryEntry> {
+        self.history.iter().filter(|e| e.is_unconfirmed())
     }
 
     /// Collect all confirmed history entries (in block order).
@@ -643,6 +654,16 @@ mod tests {
             )),
             json!({"tx_hash": "5b75086dafeede555fc8f9a810d8b10df57c46f9f176ccc3dd8d2fa20edd685b", "height": 0, "fee": 123})
         );
+    }
+
+    #[test]
+    fn test_is_unconfirmed() {
+        let txid = "5b75086dafeede555fc8f9a810d8b10df57c46f9f176ccc3dd8d2fa20edd685b"
+            .parse()
+            .unwrap();
+        assert!(!HistoryEntry::confirmed(txid, 1).is_unconfirmed());
+        assert!(HistoryEntry::unconfirmed(txid, false, Amount::from_sat(123)).is_unconfirmed());
+        assert!(HistoryEntry::unconfirmed(txid, true, Amount::from_sat(123)).is_unconfirmed());
     }
 
     #[test]


### PR DESCRIPTION
Refs #1241 — checks off the `blockchain.scripthash.get_mempool` item on the v1.6 protocol checklist.

## Summary

[`blockchain.scripthash.get_mempool`](https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-mempool) is required by Electrum protocol v1.6 and was not previously implemented in electrs.

Response shape matches `blockchain.scripthash.get_history` but filtered to mempool entries only — `{tx_hash, height, fee}` per entry, where `height` is `0` if all inputs are confirmed and `-1` otherwise.

**v1.6 ordering requirement:** the spec mandates that `get_mempool` results "must be sorted ... same order as computing scripthash status". This implementation is a filter over the existing status history, so it shares the sort key with the status hash by construction — no separate ordering logic needed.

## Test plan

- [x] 1 new unit test (`test_is_unconfirmed`) in `status::tests` plus dispatch reuses the existing `HistoryEntry` JSON shape covered by `test_txinfo_json`
- [x] `cargo test --lib` — 22/22 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Live tested against Bitcoin Core v31.0.0 on regtest. Set up a wallet, mined 101 blocks for mature coinbase, then `sendtoaddress` to a new address to produce a mempool entry:

```
$ printf '{"id":0,"method":"server.version","params":["test","1.4"]}
{"id":1,"method":"blockchain.scripthash.subscribe","params":["3c1f5806df22f16793a08cfb0e41070fabcf3c178d385072c15faec46b71a07c"]}
{"id":2,"method":"blockchain.scripthash.get_mempool","params":["3c1f5806df22f16793a08cfb0e41070fabcf3c178d385072c15faec46b71a07c"]}
{"id":3,"method":"blockchain.scripthash.get_history","params":["3c1f5806df22f16793a08cfb0e41070fabcf3c178d385072c15faec46b71a07c"]}
' | nc -w 4 127.0.0.1 60401

{"id":0,"jsonrpc":"2.0","result":["electrs/0.11.1","1.4"]}
{"id":1,"jsonrpc":"2.0","result":"c2eee7ea99189036be6b18f0c0e5d2ff2440977ff36717fcecf1f9449a6ff25a"}
{"id":2,"jsonrpc":"2.0","result":[{"fee":2820,"height":0,"tx_hash":"c8010e16520b033300d78ac385cdc1f59bed8ed0783d8836ec2009d0aa9c5583"}]}
{"id":3,"jsonrpc":"2.0","result":[{"fee":2820,"height":0,"tx_hash":"c8010e16520b033300d78ac385cdc1f59bed8ed0783d8836ec2009d0aa9c5583"}]}
```

After mining one block to confirm the tx, `get_mempool` correctly filters it out while `get_history` now reports it as confirmed:

```
{"id":2,"jsonrpc":"2.0","result":[]}
{"id":3,"jsonrpc":"2.0","result":[{"height":102,"tx_hash":"c8010e16520b033300d78ac385cdc1f59bed8ed0783d8836ec2009d0aa9c5583"}]}
```