### PR TITLE
Require `server.version` before any other Electrum RPC method

### DIFF
--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -38,6 +38,10 @@ const UNSUBSCRIBED_QUERY_MESSAGE: &str = "your wallet uses less efficient method
 pub struct Client {
     tip: Option<BlockHash>,
     scripthashes: HashMap<ScriptHash, ScriptHashStatus>,
+    /// Protocol version agreed during the `server.version` handshake.
+    /// `None` until the client successfully calls `server.version` — Electrum
+    /// protocol v1.6 requires that to happen before any other call.
+    negotiated_version: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -496,12 +500,17 @@ impl Rpc {
         format!("electrs/{}", ELECTRS_VERSION)
     }
 
-    fn version(&self, (client_id, client_version): &(String, VersionRequest)) -> Result<Value> {
+    fn version(
+        &self,
+        client: &mut Client,
+        (client_id, client_version): &(String, VersionRequest),
+    ) -> Result<Value> {
         match client_version {
             VersionRequest::Single(exact) => check_between(PROTOCOL_VERSION, exact, exact),
             VersionRequest::MinMax(min, max) => check_between(PROTOCOL_VERSION, min, max),
         }
         .with_context(|| format!("unsupported request {:?} by {}", client_version, client_id))?;
+        client.negotiated_version = Some(PROTOCOL_VERSION.to_string());
         Ok(json!([self.server_id(), PROTOCOL_VERSION]))
     }
 
@@ -590,6 +599,15 @@ impl Rpc {
             Err(response) => return response, // params parsing may fail - the response contains request id
         };
         self.rpc_duration.observe_duration(&call.method, || {
+            // Electrum protocol v1.6 requires `server.version` to be the first message sent.
+            if client.negotiated_version.is_none() && !matches!(&call.params, Params::Version(_)) {
+                return error_msg(
+                    &call.id,
+                    RpcError::BadRequest(anyhow!(
+                        "`server.version` must be called before any other method"
+                    )),
+                );
+            }
             if self.tracker.status().is_err() {
                 // Allow only a few RPC (for sync status notification) not requiring index DB being compacted.
                 match &call.params {
@@ -624,7 +642,7 @@ impl Rpc {
                 Params::TransactionGet(args) => self.transaction_get(args),
                 Params::TransactionGetMerkle(args) => self.transaction_get_merkle(args),
                 Params::TransactionFromPosition(args) => self.transaction_from_pos(*args),
-                Params::Version(args) => self.version(args),
+                Params::Version(args) => self.version(client, args),
             };
             call.response(result)
         })
@@ -843,6 +861,14 @@ mod tests {
         assert_eq!(parse_version("1.2.345").unwrap(), Version(vec![1, 2, 345]));
 
         assert!(parse_version("1.2").unwrap() < parse_version("1.100").unwrap());
+    }
+
+    #[test]
+    fn test_client_starts_without_negotiated_version() {
+        // Pre-negotiation state is what the v1.6 gate keys on:
+        // a fresh client has `negotiated_version == None` and must call `server.version` first.
+        let client = Client::default();
+        assert!(client.negotiated_version.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Refs #1241 — checks off the `server.version()` must-be-first-message item on the v1.6 protocol checklist.

## Summary

[Electrum protocol v1.6](https://electrum-protocol.readthedocs.io/en/latest/protocol-changes.html#version-1-6) mandates that `server.version` is the **first** message a client sends. Enforce this in electrs.

- Adds `negotiated_version: Option<String>` to the per-client state (`Client`)
- Set inside `fn version()` once the version handshake succeeds
- In `single_call`, reject any non-Version call when `negotiated_version.is_none()` with a JSON-RPC error that names the required method

## ⚠️ Behavior change

Any client that today sends `server.ping` / `server.banner` / `server.features` / etc. **before** the version handshake will start receiving an error. This is a deliberate v1.6 spec-compliance change.

Happy to soften this to a `warn!`-then-allow if you'd prefer a phased rollout — let me know.

## Test plan

- [x] New unit test `test_client_starts_without_negotiated_version` confirms the default-`None` state the gate keys on
- [x] `cargo test --lib` — 22/22 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Live tested against Bitcoin Core v31.0.0 on regtest, three scenarios:

```
$ # A. pre-version calls should be rejected
$ printf '{"id":1,"method":"server.ping","params":[]}
{"id":2,"method":"server.banner","params":[]}
{"id":3,"method":"server.features","params":[]}
' | nc -w 2 127.0.0.1 60401
{"error":{"code":1,"message":"`server.version` must be called before any other method"},"id":1,"jsonrpc":"2.0"}
{"error":{"code":1,"message":"`server.version` must be called before any other method"},"id":2,"jsonrpc":"2.0"}
{"error":{"code":1,"message":"`server.version` must be called before any other method"},"id":3,"jsonrpc":"2.0"}

$ # B. version first, then a regular call should succeed
$ printf '{"id":4,"method":"server.version","params":["test","1.4"]}
{"id":5,"method":"server.ping","params":[]}
{"id":6,"method":"server.banner","params":[]}
' | nc -w 2 127.0.0.1 60401
{"id":4,"jsonrpc":"2.0","result":["electrs/0.11.1","1.4"]}
{"id":5,"jsonrpc":"2.0","result":null}
{"id":6,"jsonrpc":"2.0","result":"Welcome to electrs 0.11.1 (Electrum Rust Server)!"}

$ # C. batch with version first also works (state propagates within the batch)
$ printf '[{"id":7,"method":"server.version","params":["test","1.4"]},{"id":8,"method":"server.ping","params":[]}]
' | nc -w 2 127.0.0.1 60401
[{"id":7,"jsonrpc":"2.0","result":["electrs/0.11.1","1.4"]},{"id":8,"jsonrpc":"2.0","result":null}]
```