### PR TITLE
`[env] CXXFLAGS = "-include cstdint"` added to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,7 @@ lto = true
 
 [lints.clippy]
 uninlined_format_args = "allow"  # TODO: https://github.com/romanz/electrs/issues/1199
+
+[env]
+CXXFLAGS = "-include cstdint"
+


### PR DESCRIPTION
fixes #1276
