### PR TITLE
docs: fix beta Debian repository links

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -139,7 +139,7 @@ HiddenServiceVersion 3
 HiddenServicePort 50001 127.0.0.1:50001
 ```
 
-If you use [the *beta* Debian repository](binaries.md#cnative-os-packages),
+If you use [the *beta* Debian repository](binaries.md#native-os-packages),
 it is cleaner to install `tor-hs-patch-config` using `apt` and then placing the configuration into a file inside `/etc/tor/hidden-services.d`.
 
 Restart the service:
@@ -162,7 +162,7 @@ For more details, see http://docs.electrum.org/en/latest/tor.html.
 
 ### Sample Systemd Unit File
 
-If you use [the *beta* Debian repository](binaries.md#cnative-os-packages), you should skip this section,
+If you use [the *beta* Debian repository](binaries.md#native-os-packages), you should skip this section,
 as the appropriate systemd unit file is installed automatically.
 
 You may wish to have systemd manage electrs so that it's "always on".

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -71,7 +71,7 @@ See [extra configuration suggestions](config.md#extra-configuration-suggestions)
 
 ## Electrum client
 
-If you happen to use the Electrum client from [the *beta* Debian repository](binaries.md#cnative-os-packages), it's pre-configured out-of-the-box already
+If you happen to use the Electrum client from [the *beta* Debian repository](binaries.md#native-os-packages), it's pre-configured out-of-the-box already
 Read below otherwise.
 
 There's a prepared script for launching `electrum` in such way to connect only to the local `electrs` instance to protect your privacy.


### PR DESCRIPTION
## Summary

Fix broken intra-document links to the beta Debian repository section in `doc/binaries.md`.

The links previously used `#cnative-os-packages`, but the actual heading generates the `#native-os-packages` anchor. This updates the references so they jump to the intended section.

## Testing

- `git diff --check -- doc/config.md doc/usage.md`
- `rg -n "cnative-os-packages" doc README.md` returned no matches
- Confirmed `doc/binaries.md` contains the `Native OS packages` heading