### PR TITLE
Allow setting REST server URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,9 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bindex"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1278fa172b7d90655ab8df4ab21b3956f6f0929cf1e3d97b6671188ef7c7e998"
+checksum = "becb30e2688944707fe12c33fc1d6920fc4c83f67224cd81bf2767062b852f9e"
 dependencies = [
  "bitcoin",
  "bitcoin_slices",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ spec = "internal/config_specification.toml"
 
 [dependencies]
 anyhow = "1.0"
-bindex = { version = "0.1.1", default-features = false, features = ["bitcoin_serde"] }
+bindex = { version = "0.1.2", default-features = false, features = ["bitcoin_serde"] }
 configure_me = "0.4"
 crossbeam-channel = "0.5"
 dirs-next = "2.0"

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -21,8 +21,9 @@ pub struct Tracker {
 
 impl Tracker {
     pub fn new(config: &Config, metrics: Metrics) -> Result<Self> {
-        let index =
-            IndexedChain::open(&config.db_dir, config.network).context("failed to open index")?;
+        let url = format!("http://{}", config.daemon_rpc_addr);
+        let index = IndexedChain::open(&config.db_dir, config.network, Some(url))
+            .context("failed to open index")?;
         Ok(Self {
             index,
             mempool: Mempool::new(&metrics),


### PR DESCRIPTION
Requires `bindex` 0.1.2, fixing #1315.