### PR TITLE
fix(electrum): replace panic with error for missing scripthash status in subscription

### DIFF
--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -367,7 +367,7 @@ impl Rpc {
                 Entry::Vacant(e) => {
                     let status = results
                         .remove(scripthash)
-                        .expect("missing scripthash status")?; // return an error for failed subscriptions
+                        .ok_or_else(|| anyhow::anyhow!("missing scripthash status"))??;
                     e.insert(status).statushash()
                 }
             };


### PR DESCRIPTION
I spoke to @Kixunil about this and he recommended I created a PR because we shouldn't panic here. I get these errors quite often with Sparrow and it tends to crash my electrs sometimes (#1239). Even with this fix, I get occasional crashes, but less frequent. 