### PR TITLE
Accept optional server.version arguments per the protocol

### DIFF
--- a/src/electrum.rs
+++ b/src/electrum.rs
@@ -61,6 +61,17 @@ enum VersionRequest {
     MinMax(String, String),
 }
 
+/// Default `protocol_version` when the client omits it.
+const DEFAULT_PROTOCOL_VERSION: &str = "1.4";
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum VersionArgs {
+    None([(); 0]),
+    ClientOnly((String,)),
+    ClientAndVersion((String, VersionRequest)),
+}
+
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum TxGetArgs {
@@ -490,7 +501,13 @@ impl Rpc {
         format!("electrs/{}", ELECTRS_VERSION)
     }
 
-    fn version(&self, (client_id, client_version): &(String, VersionRequest)) -> Result<Value> {
+    fn version(&self, args: &VersionArgs) -> Result<Value> {
+        let default = VersionRequest::Single(DEFAULT_PROTOCOL_VERSION.to_owned());
+        let (client_id, client_version) = match args {
+            VersionArgs::None(_) => ("", &default),
+            VersionArgs::ClientOnly((client_id,)) => (client_id.as_str(), &default),
+            VersionArgs::ClientAndVersion((client_id, version)) => (client_id.as_str(), version),
+        };
         match client_version {
             VersionRequest::Single(exact) => check_between(PROTOCOL_VERSION, exact, exact),
             VersionRequest::MinMax(min, max) => check_between(PROTOCOL_VERSION, min, max),
@@ -648,7 +665,7 @@ enum Params {
     TransactionGet(TxGetArgs),
     TransactionGetMerkle((Txid, usize)),
     TransactionFromPosition(TxFromPosArgs),
-    Version((String, VersionRequest)),
+    Version(VersionArgs),
 }
 
 impl Params {
@@ -881,6 +898,51 @@ mod tests {
             );
             assert!(
                 matches!(parsed, Ok(Params::TransactionFromPosition(_))),
+                "failed to parse {params}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_version_args() {
+        // Both `client_name` and `protocol_version` are optional per the protocol,
+        // defaulting to "" and "1.4".
+        let default = VersionRequest::Single(DEFAULT_PROTOCOL_VERSION.to_owned());
+
+        let args: VersionArgs = serde_json::from_str("[]").unwrap();
+        assert!(matches!(args, VersionArgs::None(_)));
+
+        let args: VersionArgs = serde_json::from_str(r#"["client"]"#).unwrap();
+        assert!(matches!(args, VersionArgs::ClientOnly((ref id,)) if id == "client"));
+
+        let args: VersionArgs = serde_json::from_str(r#"["client","1.4"]"#).unwrap();
+        assert!(
+            matches!(args, VersionArgs::ClientAndVersion((ref id, ref v)) if id == "client" && *v == default)
+        );
+
+        let args: VersionArgs = serde_json::from_str(r#"["client",["1.3","1.4"]]"#).unwrap();
+        assert!(matches!(
+            args,
+            VersionArgs::ClientAndVersion((_, VersionRequest::MinMax(_, _)))
+        ));
+
+        // Malformed params are still rejected.
+        assert!(serde_json::from_str::<VersionArgs>("[1]").is_err());
+        assert!(serde_json::from_str::<VersionArgs>(r#"["client","1.4",1]"#).is_err());
+    }
+
+    #[test]
+    fn test_params_version() {
+        // Every documented arity is accepted by the method dispatcher.
+        for params in [
+            "[]",
+            r#"["client"]"#,
+            r#"["client","1.4"]"#,
+            r#"["client",["1.3","1.4"]]"#,
+        ] {
+            let parsed = Params::parse("server.version", serde_json::from_str(params).unwrap());
+            assert!(
+                matches!(parsed, Ok(Params::Version(_))),
                 "failed to parse {params}"
             );
         }


### PR DESCRIPTION
The [Electrum protocol](https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#server-version) declares both `server.version` arguments as optional:

```
server.version(client_name="", protocol_version="1.4")
```

`Params::Version` held a required `(String, VersionRequest)`, so anything short of two arguments failed to deserialize and the request was rejected with `invalid params` before `version()` ran. On master:

```
Params::parse("server.version", [])          -> Err   // failed to parse []
Params::parse("server.version", ["client"])  -> Err   // one-arg form rejected
```

This mirrors the fix in #1325 for `blockchain.transaction.id_from_pos`: `VersionArgs` is an untagged arity enum, the same shape already used by `TxGetArgs`, `TxFromPosArgs` and `BroadcastArgs`. An omitted `protocol_version` defaults to `"1.4"` as the protocol specifies, rather than to `PROTOCOL_VERSION`, so the negotiation still runs through `check_between` and would correctly reject a client that relies on the default if the server's supported version ever moves past 1.4.

Tests follow the pattern of `test_tx_from_pos_args` / `test_params_id_from_pos`: one covering the arities `VersionArgs` accepts (and that malformed params are still rejected), one covering the dispatcher. Both fail on master with `failed to parse []`.

`cargo test --lib` passes (11 tests), `cargo fmt --all --check` is clean, and `cargo clippy --all-targets -- -D warnings` reports nothing.

Out of scope, noted in case you want it: a request that omits the `params` member entirely arrives as `Value::Null` rather than `[]`, which this does not accept. That affects every method, not just `server.version`, so it seemed better kept separate.

---

*Disclosure: written with AI assistance; the analysis, fix and tests were verified locally.*
