### PR TITLE
Support Bitcoin Knots BLAKE2b header v2 blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +370,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -399,6 +409,7 @@ dependencies = [
  "bitcoin-test-data",
  "bitcoin_slices",
  "bitcoincore-rpc",
+ "blake2",
  "configure_me",
  "configure_me_codegen",
  "crossbeam-channel",
@@ -1085,6 +1096,12 @@ name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ spec = "internal/config_specification.toml"
 anyhow = "1.0"
 bitcoin = { version = "0.32.6", features = ["serde", "rand-std"] }
 bitcoin_slices = { version = "0.10.0", features = ["bitcoin", "sha2"] }
+blake2 = "0.10"
 bitcoincore-rpc = { version = "0.19.0" }
 configure_me = "0.4"
 crossbeam-channel = "0.5"

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use bitcoin::blockdata::block::Header as BlockHeader;
+use crate::knots::BlockHeader;
 use bitcoin::{BlockHash, Network};
 
 /// A new header found, to be added to the chain at specific height
@@ -37,10 +37,12 @@ pub struct Chain {
 impl Chain {
     // create an empty chain
     pub fn new(network: Network) -> Self {
-        let genesis = bitcoin::blockdata::constants::genesis_block(network);
+        let genesis: BlockHeader = bitcoin::blockdata::constants::genesis_block(network)
+            .header
+            .into();
         let genesis_hash = genesis.block_hash();
         Self {
-            headers: vec![(genesis_hash, genesis.header)],
+            headers: vec![(genesis_hash, genesis)],
             heights: std::iter::once((genesis_hash, 0)).collect(), // genesis header @ zero height
         }
     }
@@ -145,7 +147,7 @@ impl Chain {
 #[cfg(test)]
 mod tests {
     use super::{Chain, NewHeader};
-    use bitcoin::blockdata::block::Header as BlockHeader;
+    use crate::knots::BlockHeader;
     use bitcoin::consensus::deserialize;
     use bitcoin::Network::Regtest;
     use hex_lit::hex;

--- a/src/db.rs
+++ b/src/db.rs
@@ -273,7 +273,20 @@ impl DBStore {
     pub(crate) fn iter_headers(&self) -> impl Iterator<Item = SerializedHeaderRow> + '_ {
         let mut opts = rocksdb::ReadOptions::default();
         opts.fill_cache(false);
-        self.iter_cf(self.headers_cf(), opts, None)
+        // Header rows are keys of two sizes (80 for legacy, 164 for BLAKE2b
+        // headers); the tip lives under TIP_KEY in the same column family.
+        let mut raw = self.db.raw_iterator_cf_opt(self.headers_cf(), opts);
+        raw.seek_to_first();
+        std::iter::from_fn(move || loop {
+            if !raw.valid() {
+                return None;
+            }
+            let key = raw.key().expect("missing key").to_vec();
+            raw.next();
+            if key.as_slice() != TIP_KEY {
+                return Some(key);
+            }
+        })
     }
 
     pub(crate) fn get_tip(&self) -> Option<Vec<u8>> {

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,11 +1,12 @@
 use anyhow::{Context, Result};
-use bitcoin::consensus::{deserialize, Decodable, Encodable};
+use bitcoin::consensus::{deserialize, Encodable};
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, OutPoint, Txid};
-use bitcoin_slices::{bsl, Visit, Visitor};
+use bitcoin_slices::{bsl, Visitor};
 use std::ops::ControlFlow;
 use std::thread;
 
+use crate::knots;
 use crate::{
     chain::{Chain, NewHeader},
     daemon::Daemon,
@@ -54,11 +55,15 @@ impl Stats {
         self.update_size.observe(label, (rows.len() * N) as f64);
     }
 
+    fn observe_size_var(&self, label: &str, rows: &[Vec<u8>]) {
+        self.update_size.observe(label, (rows.iter().map(Vec::len).sum::<usize>()) as f64);
+    }
+
     fn observe_batch(&self, batch: &WriteBatch) {
         self.observe_size("write_funding_rows", &batch.funding_rows);
         self.observe_size("write_spending_rows", &batch.spending_rows);
         self.observe_size("write_txid_rows", &batch.txid_rows);
-        self.observe_size("write_header_rows", &batch.header_rows);
+        self.observe_size_var("write_header_rows", &batch.header_rows);
         debug!(
             "writing {} funding and {} spending rows from {} transactions, {} blocks",
             batch.funding_rows.len(),
@@ -303,18 +308,12 @@ fn index_single_block(
             ControlFlow::Continue(())
         }
 
-        fn visit_block_header(&mut self, header: &bsl::BlockHeader) -> ControlFlow<()> {
-            let header = bitcoin::block::Header::consensus_decode(&mut header.as_ref())
-                .expect("block header was already validated");
-            self.batch
-                .header_rows
-                .push(HeaderRow::new(header).to_db_row());
-            ControlFlow::Continue(())
-        }
     }
 
     let mut index_block = IndexBlockVisitor { batch, height };
-    bsl::Block::visit(&block, &mut index_block).expect("core returned invalid block");
+    // The header may be the legacy or the BLAKE2b form; see knots::visit_block
+    let header = knots::visit_block(&block, &mut index_block).expect("core returned invalid block");
+    batch.header_rows.push(HeaderRow::new(header).to_db_row());
 
     let len = block_hash
         .consensus_encode(&mut (&mut batch.tip_row as &mut [u8]))

--- a/src/knots.rs
+++ b/src/knots.rs
@@ -1,0 +1,412 @@
+//! Bitcoin Knots BLAKE2b proof-of-work hardfork support.
+//!
+//! <https://github.com/bitcoinknots/bitcoin/pull/359> reshapes the block header:
+//! the top bit of the version field, when set, switches the header from the
+//! legacy 80-byte SHA256d-hashed form to a 164-byte form hashed with BLAKE2b.
+//!
+//! `bitcoin::block::Header` can only represent the legacy form, so this module
+//! provides a drop-in replacement for it. Legacy headers keep round-tripping
+//! and hashing exactly as before.
+//!
+//! The header type and its hash are adapted from Retropex's electrs fork
+//! (<https://github.com/Retropex/electrs>, commit 4453cac6, MIT), which
+//! mirrors `CBlockHeader::GetHash()` in Bitcoin Knots.
+
+use bitcoin::block::Version;
+use bitcoin::consensus::encode::{Decodable, Encodable, Error as EncodeError};
+use bitcoin::hashes::{sha256, Hash, HashEngine};
+#[cfg(test)]
+use bitcoin::hex::DisplayHex;
+use bitcoin::io::{Error as IoError, Read, Write};
+use bitcoin::{BlockHash, CompactTarget, TxMerkleNode};
+
+use blake2::digest::consts::U32;
+use blake2::{Blake2b, Digest};
+
+/// Set in the header's version field to indicate the extended (BLAKE2b) header.
+const VERSION_HEADER_V2_FLAG: u32 = 0x8000_0000;
+
+/// `flags` bit indicating that `time_offset` is subtracted from the on-wire time.
+const FLAG_USE_TIME_OFFSET: u8 = 4;
+
+/// Serialized size of a legacy header.
+pub const HEADER_V1_SIZE: usize = 80;
+/// Serialized size of an extended (BLAKE2b) header.
+pub const HEADER_V2_SIZE: usize = 164;
+
+/// A Bitcoin block header, in either the legacy or the extended (BLAKE2b) form.
+///
+/// The fields shared with the legacy header keep the names used by
+/// `bitcoin::block::Header`, so that consumers that don't care about the
+/// hardfork need no changes.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct BlockHeader {
+    /// Block version, excluding the extended-header flag.
+    pub version: Version,
+    pub prev_blockhash: BlockHash,
+    pub merkle_root: TxMerkleNode,
+    /// Block time. Note that for extended headers this is not what appears on
+    /// the wire; see [`BlockHeader::time_on_wire`].
+    pub time: u32,
+    pub bits: CompactTarget,
+    pub nonce: u32,
+
+    /// Whether this is an extended (BLAKE2b) header.
+    pub header_v2: bool,
+    /// Additional PoW/ASIC grinding nonces.
+    pub nonce2: u32,
+    pub nonce3: u32,
+    /// Stratum v1 extranonce.
+    pub extranonce: [u8; 16],
+    pub time_offset: u32,
+    /// Transaction count commitment (the fix for CVE-2017-12842).
+    pub txcount: u16,
+    pub flags: u8,
+    pub xor_key_mask_clear_bits: u8,
+    pub xor_key: [u8; 16],
+    pub height: i32,
+    /// Merge-mining hook.
+    pub mm_rhs: [u8; 32],
+}
+
+impl BlockHeader {
+    /// The version as it appears on the wire, including the extended-header flag.
+    pub fn complete_version(&self) -> u32 {
+        let version = self.version.to_consensus() as u32 & !VERSION_HEADER_V2_FLAG;
+        if self.header_v2 {
+            version | VERSION_HEADER_V2_FLAG
+        } else {
+            version
+        }
+    }
+
+    /// The block time as it appears on the wire, which the extended header may
+    /// carry offset by `time_offset`.
+    pub fn time_on_wire(&self) -> u32 {
+        if self.flags & FLAG_USE_TIME_OFFSET == 0 {
+            self.time
+        } else {
+            self.time.wrapping_sub(self.time_offset)
+        }
+    }
+
+    /// The serialized size of this header.
+    pub fn size(&self) -> usize {
+        if self.header_v2 {
+            HEADER_V2_SIZE
+        } else {
+            HEADER_V1_SIZE
+        }
+    }
+
+    pub fn block_hash(&self) -> BlockHash {
+        if !self.header_v2 {
+            // Historical algorithm and common case: SHA256d over the 80 bytes.
+            let mut engine = BlockHash::engine();
+            self.consensus_encode(&mut engine)
+                .expect("engines don't error");
+            return BlockHash::from_engine(engine);
+        }
+        self.blake2b_block_hash()
+    }
+
+    /// The BLAKE2b hash of an extended header, mirroring `CBlockHeader::GetHash()`.
+    fn blake2b_block_hash(&self) -> BlockHash {
+        // A pooling miner only learns `xor_key` once it finds a block, so the
+        // header commits to the key's hash rather than to the key itself.
+        let xor_key_hash = tagged_hash("Bitcoin block hash PoW XOR key", &[&self.xor_key]);
+
+        let mut xor_key_mask = [0u8; 32];
+        if self.xor_key != [0u8; 16] {
+            xor_key_mask = tagged_hash("Bitcoin block hash PoW XOR mask", &[&self.xor_key]);
+            // `clear_bits` is a u8, so this stays in bounds.
+            let clear_bytes = usize::from(self.xor_key_mask_clear_bits / 8);
+            xor_key_mask[..clear_bytes].fill(0);
+            xor_key_mask[clear_bytes] &= 0xffu8 >> (self.xor_key_mask_clear_bits % 8);
+        }
+
+        let mut prevblock_ordered = self.prev_blockhash.to_byte_array();
+        prevblock_ordered.reverse();
+        let mut prevblock_hidden =
+            tagged_hash("Bitcoin prevblock header, hashed", &[&prevblock_ordered]);
+
+        // These fields are invisible to the mining machine, so the hasher cannot
+        // brick itself at some future block version, time or difficulty.
+        let h1 = tagged_hash(
+            "Bitcoin block header 1",
+            &[
+                &self.complete_version().to_le_bytes(),
+                &prevblock_ordered,
+                &self.height.to_le_bytes(),
+                self.merkle_root.as_byte_array(),
+                &self.time_on_wire().to_le_bytes(),
+                &[0], // reserved for extended 40-bit time
+                &self.bits.to_consensus().to_le_bytes(),
+                &u32::from(self.txcount).to_le_bytes(),
+                &[self.flags, self.xor_key_mask_clear_bits],
+                &xor_key_hash,
+            ],
+        );
+
+        let h2 = tagged_hash("Merge-mining hook", &[&h1, &[0u8; 32], &self.mm_rhs]);
+
+        // These fields get sent to mining machines over Stratum v1.
+        let hash = blake2b_256(&[
+            &[0u8; 4], // final 3 bytes are part of Sv1 "coinb1"
+            &h2,
+            &self.extranonce,
+        ]);
+
+        // Presumably the actual mining ASIC hardware sees these.
+        let tail: [&[u8]; 5] = [
+            &self.nonce.to_le_bytes(),
+            &self.nonce2.to_le_bytes(),
+            &self.time_offset.to_le_bytes(),
+            &self.nonce3.to_le_bytes(),
+            &hash,
+        ];
+        let hash = match self.flags & 3 {
+            0 => {
+                prevblock_hidden[..6].fill(0);
+                blake2b_256(&[
+                    &prevblock_hidden,
+                    tail[0],
+                    tail[1],
+                    tail[2],
+                    tail[3],
+                    tail[4],
+                ])
+            }
+            1 => blake2b_256(&[
+                &self.nonce.to_le_bytes(),
+                &self.nonce2.to_le_bytes(),
+                &self.nonce3.to_le_bytes(),
+                &self.time_offset.to_le_bytes(),
+                &hash,
+                &h2,
+            ]),
+            2 => blake2b_256(&[&[0u8; 48], &h2, tail[0], tail[1], tail[2], tail[3], tail[4]]),
+            _ => blake2b_256(&[&[0u8; 80], &h2, tail[0], tail[1], tail[2], tail[3], tail[4]]),
+        };
+
+        let mut inner = [0u8; 32];
+        for (i, byte) in inner.iter_mut().rev().enumerate() {
+            *byte = hash[i] ^ xor_key_mask[i];
+        }
+        BlockHash::from_byte_array(inner)
+    }
+}
+
+impl Encodable for BlockHeader {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, IoError> {
+        let mut len = 0;
+        len += self.complete_version().consensus_encode(w)?;
+        len += self.prev_blockhash.consensus_encode(w)?;
+        len += self.merkle_root.consensus_encode(w)?;
+        len += self.time_on_wire().consensus_encode(w)?;
+        len += self.bits.consensus_encode(w)?;
+        len += self.nonce.consensus_encode(w)?;
+        if self.header_v2 {
+            len += self.nonce2.consensus_encode(w)?;
+            len += self.nonce3.consensus_encode(w)?;
+            len += self.extranonce.consensus_encode(w)?;
+            len += self.time_offset.consensus_encode(w)?;
+            len += self.txcount.consensus_encode(w)?;
+            len += self.flags.consensus_encode(w)?;
+            len += self.xor_key_mask_clear_bits.consensus_encode(w)?;
+            len += self.xor_key.consensus_encode(w)?;
+            len += self.height.consensus_encode(w)?;
+            len += self.mm_rhs.consensus_encode(w)?;
+        }
+        Ok(len)
+    }
+}
+
+impl Decodable for BlockHeader {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, EncodeError> {
+        let version = u32::consensus_decode(r)?;
+        let mut header = BlockHeader {
+            version: Version::from_consensus((version & !VERSION_HEADER_V2_FLAG) as i32),
+            prev_blockhash: BlockHash::consensus_decode(r)?,
+            merkle_root: TxMerkleNode::consensus_decode(r)?,
+            time: u32::consensus_decode(r)?, // on-wire time, adjusted below
+            bits: CompactTarget::consensus_decode(r)?,
+            nonce: u32::consensus_decode(r)?,
+
+            header_v2: version & VERSION_HEADER_V2_FLAG != 0,
+            nonce2: 0,
+            nonce3: 0,
+            extranonce: [0u8; 16],
+            time_offset: 0,
+            txcount: 0,
+            flags: 0,
+            xor_key_mask_clear_bits: 0,
+            xor_key: [0u8; 16],
+            height: 0,
+            mm_rhs: [0u8; 32],
+        };
+        if header.header_v2 {
+            header.nonce2 = u32::consensus_decode(r)?;
+            header.nonce3 = u32::consensus_decode(r)?;
+            header.extranonce = <[u8; 16]>::consensus_decode(r)?;
+            header.time_offset = u32::consensus_decode(r)?;
+            header.txcount = u16::consensus_decode(r)?;
+            header.flags = u8::consensus_decode(r)?;
+            header.xor_key_mask_clear_bits = u8::consensus_decode(r)?;
+            header.xor_key = <[u8; 16]>::consensus_decode(r)?;
+            header.height = i32::consensus_decode(r)?;
+            header.mm_rhs = <[u8; 32]>::consensus_decode(r)?;
+        }
+        if header.flags & FLAG_USE_TIME_OFFSET != 0 {
+            header.time = header.time.wrapping_add(header.time_offset);
+        }
+        Ok(header)
+    }
+}
+
+impl From<bitcoin::block::Header> for BlockHeader {
+    fn from(h: bitcoin::block::Header) -> Self {
+        BlockHeader {
+            version: h.version,
+            prev_blockhash: h.prev_blockhash,
+            merkle_root: h.merkle_root,
+            time: h.time,
+            bits: h.bits,
+            nonce: h.nonce,
+            header_v2: false,
+            nonce2: 0,
+            nonce3: 0,
+            extranonce: [0u8; 16],
+            time_offset: 0,
+            txcount: 0,
+            flags: 0,
+            xor_key_mask_clear_bits: 0,
+            xor_key: [0u8; 16],
+            height: 0,
+            mm_rhs: [0u8; 32],
+        }
+    }
+}
+
+/// Walk a serialized block through a `bitcoin_slices` visitor.
+///
+/// `bsl::Block::visit` assumes an 80-byte header, so it cannot parse a block
+/// with an extended header. This reads the header in either form, then the
+/// transaction count, then each transaction through the visitor, with the
+/// same `visit_block_begin` call and the same `Err(VisitBreak)` on an early
+/// stop that `bsl::Block::visit` gives. `visit_block_header` is not called,
+/// since an extended header has no `bsl` representation; nothing in electrs
+/// implements it.
+pub fn visit_block<V: bitcoin_slices::Visitor>(
+    block: &[u8],
+    visitor: &mut V,
+) -> Result<BlockHeader, bitcoin_slices::Error> {
+    use bitcoin::consensus::encode::VarInt;
+    use bitcoin_slices::{bsl, Error, Visit};
+
+    let header = BlockHeader::consensus_decode(&mut &block[..]).map_err(|_| Error::MoreBytesNeeded)?;
+    let mut cursor = &block[header.size()..];
+    let txcount = VarInt::consensus_decode(&mut cursor)
+        .map_err(|_| Error::MoreBytesNeeded)?
+        .0 as usize;
+    visitor.visit_block_begin(txcount);
+    for _ in 0..txcount {
+        let parsed = bsl::Transaction::visit(cursor, visitor)?;
+        cursor = parsed.remaining();
+    }
+    Ok(header)
+}
+
+/// BIP340-style tagged SHA256, as Bitcoin Core's `TaggedHash`.
+fn tagged_hash(tag: &str, parts: &[&[u8]]) -> [u8; 32] {
+    let tag_hash = sha256::Hash::hash(tag.as_bytes());
+    let mut engine = sha256::Hash::engine();
+    engine.input(tag_hash.as_byte_array());
+    engine.input(tag_hash.as_byte_array());
+    for part in parts {
+        engine.input(part);
+    }
+    sha256::Hash::from_engine(engine).to_byte_array()
+}
+
+fn blake2b_256(parts: &[&[u8]]) -> [u8; 32] {
+    let mut hasher = Blake2b::<U32>::new();
+    for part in parts {
+        hasher.update(part);
+    }
+    hasher.finalize().into()
+}
+
+/// (serialized header, block hash) vectors from Knots'
+/// `src/test/data/block_header_v2.json`, covering all four ASIC profiles.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::consensus::{deserialize, serialize};
+    use bitcoin::hex::FromHex;
+
+    #[test]
+    fn blake2b_256_test_vectors() {
+        // RFC 7693 style checks for the 32-byte output
+        assert_eq!(
+            blake2b_256(&[b""]).to_lower_hex_string(),
+            "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
+        );
+        assert_eq!(
+            blake2b_256(&[b"abc"]).to_lower_hex_string(),
+            "bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319"
+        );
+    }
+
+    #[test]
+    fn legacy_header_unchanged() {
+        // regtest genesis header: 80 bytes, SHA256d hash, no v2 flag
+        let genesis = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Regtest);
+        let ours: BlockHeader = genesis.header.into();
+        assert!(!ours.header_v2);
+        assert_eq!(ours.size(), HEADER_V1_SIZE);
+        assert_eq!(serialize(&ours), serialize(&genesis.header));
+        assert_eq!(ours.block_hash(), genesis.header.block_hash());
+        let back: BlockHeader = deserialize(&serialize(&genesis.header)).unwrap();
+        assert_eq!(back, ours);
+    }
+
+    /// Bitcoin Knots' own vectors (src/test/data/block_header_v2.json at
+    /// v29.4.1.knots20260508rc4): the serialized header and the resulting
+    /// block hash in digest order.
+    #[test]
+    fn knots_header_v2_vectors() {
+        let json: serde_json::Value = serde_json::from_str(include_str!("knots_vectors.json")).unwrap();
+        let headers = json["headers"].as_array().unwrap();
+        assert!(headers.len() >= 5);
+        for v in headers {
+            let name = v["name"].as_str().unwrap();
+            let bytes = Vec::<u8>::from_hex(v["serialized"].as_str().unwrap()).unwrap();
+            assert_eq!(bytes.len(), HEADER_V2_SIZE, "{}", name);
+            let header: BlockHeader = deserialize(&bytes).unwrap_or_else(|e| panic!("{}: {}", name, e));
+            assert!(header.header_v2, "{}", name);
+            assert_eq!(serialize(&header), bytes, "{}: round trip", name);
+            assert_eq!(header.block_hash().to_string(), v["block_hash"].as_str().unwrap(), "{}: block hash", name);
+        }
+    }
+
+    /// Random headers hashed by an independent Python implementation
+    /// (hdrv2.py). Set KNOTS_RANDOM_VECTORS to the JSON file to run it.
+    #[test]
+    fn random_vectors_differential() {
+        let path = match std::env::var("KNOTS_RANDOM_VECTORS") {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let json: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        let vectors = json.as_array().unwrap();
+        assert!(vectors.len() >= 100);
+        for (i, v) in vectors.iter().enumerate() {
+            let bytes = Vec::<u8>::from_hex(v["serialized"].as_str().unwrap()).unwrap();
+            let header: BlockHeader = deserialize(&bytes).unwrap_or_else(|e| panic!("vector {}: {}", i, e));
+            assert_eq!(serialize(&header), bytes, "vector {}: round trip", i);
+            assert_eq!(header.block_hash().to_string(), v["block_hash"].as_str().unwrap(), "vector {}", i);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod daemon;
 mod db;
 mod electrum;
 mod index;
+mod knots;
 mod mempool;
 mod merkle;
 mod metrics;

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use bitcoin::blockdata::block::Header as BlockHeader;
+use crate::knots::BlockHeader;
 use bitcoin::consensus::Encodable;
 use bitcoin::{
     consensus::{
@@ -15,9 +15,8 @@ use bitcoin::{
         message_network, Magic,
     },
     secp256k1::{self, rand::Rng},
-    Block, BlockHash, Network,
+    BlockHash, Network,
 };
-use bitcoin_slices::{bsl, Parse};
 use crossbeam_channel::{bounded, select, Receiver, Sender};
 
 use std::io::Write;
@@ -114,13 +113,9 @@ impl Connection {
                         .blocks_recv
                         .recv()
                         .with_context(|| format!("failed to get block {}", hash))?;
-                    let header = bsl::BlockHeader::parse(&block[..])
-                        .expect("core returned invalid blockheader")
-                        .parsed_owned();
-                    ensure!(
-                        &header.block_hash_sha2()[..] == hash.as_byte_array(),
-                        "got unexpected block"
-                    );
+                    let header = BlockHeader::consensus_decode(&mut &block[..])
+                        .expect("core returned invalid blockheader");
+                    ensure!(header.block_hash() == hash, "got unexpected block");
                     Ok(block)
                 })?;
                 self.blocks_duration
@@ -360,7 +355,10 @@ impl RawNetworkMessage {
                 let len = VarInt::consensus_decode(&mut raw)?.0;
                 let mut headers = Vec::with_capacity(len as usize);
                 for _ in 0..len {
-                    headers.push(Block::consensus_decode(&mut raw)?.header);
+                    // Each entry is a header (80 or 164 bytes) followed by a zero tx count
+                    let header = BlockHeader::consensus_decode(&mut raw)?;
+                    let _txcount = VarInt::consensus_decode(&mut raw)?;
+                    headers.push(header);
                 }
                 ParsedNetworkMessage::Headers(headers)
             }

--- a/src/status.rs
+++ b/src/status.rs
@@ -4,7 +4,7 @@ use bitcoin::{
     hashes::{sha256, Hash, HashEngine},
     Amount, BlockHash, OutPoint, SignedAmount, Transaction, Txid,
 };
-use bitcoin_slices::{bsl, Visit, Visitor};
+use bitcoin_slices::{bsl, Visitor};
 use rayon::prelude::*;
 use serde::ser::{Serialize, Serializer};
 
@@ -559,7 +559,7 @@ fn filter_block_txs_outputs(block: SerBlock, scripthash: ScriptHash) -> Vec<Filt
         pos: 0,
     };
 
-    bsl::Block::visit(&block, &mut find_outputs).expect("core returned invalid block");
+    crate::knots::visit_block(&block, &mut find_outputs).expect("core returned invalid block");
 
     find_outputs.result
 }
@@ -606,7 +606,7 @@ fn filter_block_txs_inputs(
         pos: 0,
     };
 
-    bsl::Block::visit(block, &mut find_inputs).expect("core returned invalid block");
+    crate::knots::visit_block(block, &mut find_inputs).expect("core returned invalid block");
 
     find_inputs.result
 }

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -2,7 +2,7 @@ use std::ops::ControlFlow;
 
 use anyhow::{Context, Result};
 use bitcoin::{BlockHash, Txid};
-use bitcoin_slices::{bsl, Error::VisitBreak, Visit, Visitor};
+use bitcoin_slices::{bsl, Error::VisitBreak, Visitor};
 
 use crate::{
     cache::Cache,
@@ -115,7 +115,7 @@ impl Tracker {
                 return; // keep first matching transaction
             }
             let mut visitor = FindTransaction::new(txid);
-            result = match bsl::Block::visit(&block, &mut visitor) {
+            result = match crate::knots::visit_block(&block, &mut visitor) {
                 Ok(_) | Err(VisitBreak) => visitor.found.map(|tx| (blockhash, tx)),
                 Err(e) => panic!("core returned invalid block: {:?}", e),
             };

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,9 +2,9 @@ use anyhow::Result;
 
 use std::convert::TryFrom;
 
-use bitcoin::blockdata::block::Header as BlockHeader;
+use crate::knots::BlockHeader;
 use bitcoin::{
-    consensus::encode::{deserialize, Decodable, Encodable},
+    consensus::encode::{deserialize, serialize, Decodable, Encodable},
     hashes::{hash_newtype, sha256, Hash},
     io, OutPoint, Script, Txid,
 };
@@ -163,14 +163,13 @@ impl TxidRow {
 
 // ***************************************************************************
 
-pub(crate) type SerializedHeaderRow = [u8; HEADER_ROW_SIZE];
+/// A serialized header: 80 bytes for a legacy header, 164 for a BLAKE2b one.
+pub(crate) type SerializedHeaderRow = Vec<u8>;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 pub(crate) struct HeaderRow {
     pub(crate) header: BlockHeader,
 }
-
-pub const HEADER_ROW_SIZE: usize = 80;
 
 impl_consensus_encoding!(HeaderRow, header);
 
@@ -180,11 +179,8 @@ impl HeaderRow {
     }
 
     pub(crate) fn to_db_row(&self) -> SerializedHeaderRow {
-        let mut row = [0; HEADER_ROW_SIZE];
-        let len = self
-            .consensus_encode(&mut (&mut row as &mut [u8]))
-            .expect("in-memory writers don't error");
-        debug_assert_eq!(len, HEADER_ROW_SIZE);
+        let row = serialize(self);
+        debug_assert_eq!(row.len(), self.header.size());
         row
     }
 


### PR DESCRIPTION
## What
Support for Bitcoin Knots' BLAKE2b hardfork blocks: a header type that decodes both the legacy 80-byte header and the 164-byte header-v2 form (version bit 31), hashes each the way `CBlockHeader::GetHash()` does, and the small changes around it so P2P sync, the header chain, the database rows, block indexing and the Electrum calls all accept either form.

## Why
Bitcoin Knots v29.4.1 forked mainnet at height 961640 to BLAKE2b proof of work with a longer header. rust-bitcoin's `Header` is fixed at 80 bytes, so an electrs following a Knots node dies on the first `headers` message past the fork ("failed to parse unsupported segwit version: 99") and restarts in a loop. Nothing changes for a node on the SHA256d chain: a legacy header decodes, encodes and hashes exactly as before, on-disk rows stay 80 bytes, and a set bit 31 cannot occur there because Core rejects those blocks as `bad-version`.

The header type and its hash are adapted from Retropex's electrs fork (mempool/electrs lineage, MIT), credited in the module.

## How I tested
- `cargo test`: the existing suite passes unchanged, plus the five header-v2 vectors from Knots' `src/test/data/block_header_v2.json` (round trip and block hash), 2000 random v2 headers hashed by an independent Python implementation (set `KNOTS_RANDOM_VECTORS`), and a check that a legacy header still serializes and hashes byte for byte as `bitcoin::block::Header`.
- On a mainnet Knots node past the fork, first against a copy of an existing 59 GB index and then in production: the 961,639 legacy rows loaded as before, the new blocks indexed, `blockchain.headers.subscribe` returns a 164-byte tip, `blockchain.block.header` returns 80 bytes for 961639 and 164 for 961640, a `block.headers` range spanning the fork concatenates correctly, and `scripthash.get_history` for a coinbase output mined at 961672 returns it with the right balance.

## Risk and rollback
No behavior change on a SHA256d chain; the v2 branch is unreachable there. Databases written by this version are readable by the previous one as long as no v2 block has been indexed. Revert the commit.

## Still unsure about
Whether you want this behind a Cargo feature (`knots-blake2b`, default off) to keep the `blake2` dependency out of the default build. The code splits cleanly that way; I left it unconditional because the legacy path is identical either way, but I will gate it if you prefer.
