### PR TITLE
docs: clarify script-hash status wording

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -378,7 +378,7 @@ impl ScriptHashStatus {
     }
 
     /// Sync with currently confirmed txs and mempool, downloading non-cached transactions via REST API.
-    /// After a successful sync, scripthash status is updated.
+    /// After a successful sync, script-hash status is updated.
     pub(crate) fn sync(&mut self, index: &IndexedChain, mempool: &Mempool) -> Result<()> {
         let outpoints = self.sync_confirmed(index)?;
         if !self.confirmed.is_empty() {


### PR DESCRIPTION
Clarify script-hash terminology in the status documentation so it matches electrs and Bitcoin RPC usage.